### PR TITLE
feat: add Docker support for easy deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8-slim
+
+WORKDIR /app
+
+# Copier les fichiers nécessaires
+COPY . /app/
+
+# Installer les dépendances
+RUN pip install --no-cache-dir poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --no-dev
+
+# Définir les variables d'environnement
+ENV PYTHONUNBUFFERED=1
+
+# Commande par défaut
+ENTRYPOINT ["python", "-m", "glpwnme"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ pip3 install .
 python3 -m glpwnme
 ```
 
+## :whale: Docker
+You can also run glpwnme using Docker, which eliminates the need to install dependencies locally:
+
+```bash
+# Build and start the container
+docker compose build
+
+# Run glpwnme with arguments
+docker compose run glpwnme -t https://target.glpi.com --check-all
+
+# List plugins example
+docker compose run glpwnme -t https://target.glpi.com --list-plugins
+
+# Run a specific exploit
+docker compose run glpwnme -t https://target.glpi.com -e <exploit_name> --run
+```
+
+The container mounts the current directory as a volume, so all generated files (like `log.glpwnme`) will be available on your local machine.
+
 ## :bomb: Vulnerabilities available
 
 | Name                 | Score | Privileges | Vulnerable versions |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  glpwnme:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: glpwnme
+    volumes:
+      - ./:/app
+    # Pour passer des arguments lors du lancement
+    # Exemple: docker-compose run glpwnme -t https://target.glpi.com --check-all
+    entrypoint: ["python", "-m", "glpwnme"]
+    # Ne démarre pas automatiquement, attend les arguments de l'utilisateur
+    command: ["--help"]
+    network_mode: "host"


### PR DESCRIPTION
## Description
This PR adds Docker support to the glpwnme project to facilitate deployment and usage without having to manually configure the Python environment and dependencies.

## Changes
- Added a `Dockerfile` configured for Python 3.8 and Poetry installation
- Added a `docker-compose.yml` file to simplify execution
- Updated README with a new `:whale: Docker` section explaining how to use the project with Docker

## Benefits
- Simplified deployment and usage of the project
- Isolation of dependencies in a container
- Consistent execution environment across users
- No need to install Python dependencies locally

## How to test
```bash
# Build the image
docker compose build

# Run a basic test
docker compose run glpwnme --help

# Test with an actual target
docker compose run glpwnme -t https://target.glpi.com --list-plugins