### PR TITLE
fix: Dockerfile (python:3.10-slim and poetry install --only main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ COPY . /app/
 # Installer les dépendances
 RUN pip install --no-cache-dir poetry && \
     poetry config virtualenvs.create false && \
-    poetry install --no-dev
+    poetry install --only main
 
 # Définir les variables d'environnement
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Dockerfile fix: update base image to `python:3.10-slim` and fix `poetry install --only main` for a working build.